### PR TITLE
Inherit defect related triples when operations are performed on the structure

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.9.10
+current_version = 0.9.11
 commit = True
 tag = False
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -19,4 +19,4 @@ url: 'https://atomrdf.pyscal.org'
 license: "MIT"
 repository-code: https://github.com/pyscal/atomRDF
 type: software
-version: 0.9.10
+version: 0.9.11

--- a/atomrdf/graph.py
+++ b/atomrdf/graph.py
@@ -1262,8 +1262,15 @@ class KnowledgeGraph:
                     if self._is_bnode(triple[0]):
                         uri_dict[triple[0].toPython()] = self._create_a_new_name(triple[0].toPython())
                     else:
-                        uri_dict[triple[0].toPython()] = None
-        return uri_dict
+                        uri_dict[triple[0].toPython()] = triple[0].toPython()
+        
+        for triple in triples:
+            if triple[0].toPython() in uri_dict.keys():
+                triples[0] = uri_dict[triple[0].toPython()]
+            if triple[2].toPython() in uri_dict.keys():
+                triples[2] = uri_dict[triple[2].toPython()]
+        
+        return uri_dict[item.toPython()], triples
                 
     def get_sample(self, sample, no_atoms=False, stop_at_sample=True):
         """

--- a/atomrdf/graph.py
+++ b/atomrdf/graph.py
@@ -1266,9 +1266,9 @@ class KnowledgeGraph:
         
         for triple in triples:
             if triple[0].toPython() in uri_dict.keys():
-                triples[0] = uri_dict[triple[0].toPython()]
+                triples[0] = URIRef(uri_dict[triple[0].toPython()])
             if triple[2].toPython() in uri_dict.keys():
-                triples[2] = uri_dict[triple[2].toPython()]
+                triples[2] = URIRef(uri_dict[triple[2].toPython()])
         
         return URIRef(uri_dict[item.toPython()]), triples
                 

--- a/atomrdf/graph.py
+++ b/atomrdf/graph.py
@@ -1270,7 +1270,7 @@ class KnowledgeGraph:
             if triple[2].toPython() in uri_dict.keys():
                 triples[2] = uri_dict[triple[2].toPython()]
         
-        return uri_dict[item.toPython()], triples
+        return URIRef(uri_dict[item.toPython()]), triples
                 
     def get_sample(self, sample, no_atoms=False, stop_at_sample=True):
         """

--- a/atomrdf/graph.py
+++ b/atomrdf/graph.py
@@ -1287,7 +1287,7 @@ class KnowledgeGraph:
         material = list([k[2] for k in self.triples((sample, CMSO.hasMaterial, None))])[0]
 
         for defect in parent_defects:
-            new_defect, defect_triples = self.graph.iterate_and_rename_triples(defect)
+            new_defect, defect_triples = self.iterate_and_rename_triples(defect)
             #add the new defect to the new material
             self.add((material, CMSO.hasDefect, new_defect))
             #add the triples to the graph

--- a/atomrdf/graph.py
+++ b/atomrdf/graph.py
@@ -1264,13 +1264,18 @@ class KnowledgeGraph:
                     else:
                         uri_dict[triple[0].toPython()] = triple[0].toPython()
         
+        new_triples = []
         for triple in triples:
-            if triple[0].toPython() in uri_dict.keys():
-                triples[0] = URIRef(uri_dict[triple[0].toPython()])
-            if triple[2].toPython() in uri_dict.keys():
-                triples[2] = URIRef(uri_dict[triple[2].toPython()])
+            subject = triple[0]
+            if subject.toPython() in uri_dict.keys():
+                subject = URIRef(uri_dict[subject.toPython()])
+            predicate  = triple[1]
+            object = triple[2]
+            if object.toPython() in uri_dict.keys():
+                object = URIRef(uri_dict[object.toPython()])
+            new_triples.append((subject, predicate, object))
         
-        return URIRef(uri_dict[item.toPython()]), triples
+        return URIRef(uri_dict[item.toPython()]), new_triples
                 
     def get_sample(self, sample, no_atoms=False, stop_at_sample=True):
         """

--- a/atomrdf/graph.py
+++ b/atomrdf/graph.py
@@ -1245,7 +1245,7 @@ class KnowledgeGraph:
                     uri_dict[triple[0].toPython()] = None
         return uri_dict
                 
-    def get_sample(self, sample, no_atoms=False):
+    def get_sample(self, sample, no_atoms=False, stop_at_sample=True):
         """
         Get the Sample as a KnowledgeGraph
 
@@ -1256,6 +1256,9 @@ class KnowledgeGraph:
 
         no_atoms: bool, optional
             if True, returns the number of atoms in the sample
+
+        stop_at_sample: bool, optional
+            if True, stops the iteration at the when a sample object is encountered. Default is True.
 
         Returns
         -------
@@ -1268,11 +1271,11 @@ class KnowledgeGraph:
         if isinstance(sample, str):
             sample = URIRef(sample)
 
-        _ = self.iterate_graph(sample, create_new_graph=True)
+        sgraph = self.iterate_and_create_graph(sample, stop_at_sample=stop_at_sample)
         if no_atoms:
-            na = self.sgraph.value(sample, CMSO.hasNumberOfAtoms).toPython()
-            return self.sgraph, na
-        return self.sgraph
+            na = sgraph.value(sample, CMSO.hasNumberOfAtoms).toPython()
+            return sgraph, na
+        return sgraph
     
     def get_label(self, item):
         label = self.graph.value(item, RDFS.label)

--- a/atomrdf/graph.py
+++ b/atomrdf/graph.py
@@ -1233,7 +1233,24 @@ class KnowledgeGraph:
             sgraph.add(triple)
         return sgraph
 
-    def iterate_and_reapply_triples(self, item):
+    def _create_a_new_name(self, uristring):
+        """
+        take a given uriref string name and create one in similar fashion
+        """
+        raw = uristring.split(':')
+        if len(raw) > 1:
+            prologue = raw[0]+':'
+        else:
+            prologue = ''
+        
+        raw = uristring.split('_')
+        if len(raw) > 1:
+            epilogue = '_'+"_".join(raw[1:])
+        else:
+            epilogue = ''
+        return f"{prologue}{uuid.uuid4()}{epilogue}"
+
+    def iterate_and_rename_triples(self, item):
         self.iterate_graph(item, create_new_list=True)
         triples = copy.deepcopy(self.slist)
         #now we have to edit this triples, and reapply them
@@ -1242,7 +1259,10 @@ class KnowledgeGraph:
         for triple in triples:
             if isinstance(triple[0], URIRef):
                 if triple[0].toPython() not in uri_dict.keys():
-                    uri_dict[triple[0].toPython()] = None
+                    if self._is_bnode(triple[0]):
+                        uri_dict[triple[0].toPython()] = self._create_a_new_name(triple[0].toPython())
+                    else:
+                        uri_dict[triple[0].toPython()] = None
         return uri_dict
                 
     def get_sample(self, sample, no_atoms=False, stop_at_sample=True):

--- a/atomrdf/graph.py
+++ b/atomrdf/graph.py
@@ -1161,7 +1161,7 @@ class KnowledgeGraph:
 
         return [x[0] for x in self.triples((None, RDF.type, PROV.Activity))]
     
-    def iterate_graph(self, item, create_new_graph=False):
+    def iterate_graph(self, item, create_new_graph=False, create_new_list=False):
         """
         Iterate through the graph starting from the given item.
 
@@ -1177,16 +1177,40 @@ class KnowledgeGraph:
         -------
         None
         """
-        if isinstance(item, str):
-            item = URIRef(item)
+        #active = False
 
-        if create_new_graph:
-            self.sgraph = KnowledgeGraph()
+        if not type(item).__name__ == 'URIRef':
+            return
+
+        #if create_new_graph:
+        #    self.sgraph = KnowledgeGraph()
+        
+        if create_new_list:
+            self.slist = []
+
         triples = list(self.triples((item, None, None)))
+        #print(triples)
+        
         for triple in triples:
-            self.sgraph.graph.add(triple)
+            #active = True
+            #if create_new_graph:
+            #    self.sgraph.graph.add(triple)
+            self.slist.append(triple)
             self.iterate_graph(triple[2])
-
+    
+    def iterate_and_reapply_triples(self, item):
+        self.iterate_graph(item, create_new_list=True)
+        triples = copy.deepcopy(self.slist)
+        #now we have to edit this triples, and reapply them
+        #for that we make a dict of all URIRef values in this graph
+        uri_dict = {}
+        for triple in triples:
+            if isinstance(triple[0], URIRef):
+                print(triple[0])
+                if triple[0].toPython() not in uri_dict.keys():
+                    uri_dict[triple[0].toPython()] = None
+        return uri_dict
+                
     def get_sample(self, sample, no_atoms=False):
         """
         Get the Sample as a KnowledgeGraph
@@ -1210,7 +1234,7 @@ class KnowledgeGraph:
         if isinstance(sample, str):
             sample = URIRef(sample)
 
-        self.iterate_graph(sample, create_new_graph=True)
+        _ = self.iterate_graph(sample, create_new_graph=True)
         if no_atoms:
             na = self.sgraph.value(sample, CMSO.hasNumberOfAtoms).toPython()
             return self.sgraph, na

--- a/atomrdf/structure.py
+++ b/atomrdf/structure.py
@@ -2573,4 +2573,5 @@ class System(pc.System):
             self.graph.add((material, CMSO.hasDefect, new_defect))
             #add the triples to the graph
             for triple in defect_triples:
-                self.graph.add((triple))        
+                #print(triple)
+                self.graph.add(triple)        

--- a/atomrdf/structure.py
+++ b/atomrdf/structure.py
@@ -936,6 +936,7 @@ class System(pc.System):
             new_system._structure_dict = {}
         new_system._structure_dict["repetitions"] = repetitions
         new_system.to_graph()
+        new_system.copy_defects(self.sample)
         return new_system
     
     def delete(self, ids=None, indices=None, condition=None, selection=False, copy_structure=False):
@@ -968,6 +969,7 @@ class System(pc.System):
             sys = self.duplicate()
             #and add this new structure to the graph
             sys.to_graph()
+            sys.copy_defects(self.sample)
         else:
             sys = self
         
@@ -1184,6 +1186,7 @@ class System(pc.System):
             sys = self.duplicate()
             #and add this new structure to the graph
             sys.to_graph()
+            sys.copy_defects(self.sample)
         else:
             sys = self
         
@@ -1386,6 +1389,7 @@ class System(pc.System):
             #sys = self.duplicate()
             sys = System(source=sys.add_atoms({"positions": randpos, "species": element}))        
             sys.to_graph()
+            sys.copy_defects(self.sample)
         else:
             #sys = self.duplicate()
             sys = System(source=self.add_atoms({"positions": randpos, "species": element}))
@@ -2410,6 +2414,7 @@ class System(pc.System):
         else:
             output_structure.label = self.label
         output_structure.to_graph()
+        output_structure.copy_defects(self.sample)
         if output_structure.graph is not None:
             self.add_rotation_triples(rotation_vectors, output_structure.sample)
         return output_structure
@@ -2467,6 +2472,7 @@ class System(pc.System):
             sys = self.duplicate()
             #and add this new structure to the graph
             sys.to_graph()
+            sys.copy_defects(self.sample)
         else:
             sys = self
 
@@ -2518,6 +2524,7 @@ class System(pc.System):
             sys = self.duplicate()
             #and add this new structure to the graph
             sys.to_graph()
+            sys.copy_defects(self.sample)
         else:
             sys = self
 

--- a/atomrdf/structure.py
+++ b/atomrdf/structure.py
@@ -2566,5 +2566,9 @@ class System(pc.System):
         material = list([k[2] for k in self.kg.triples((self.sample, CMSO.hasMaterial, None))])[0]
 
         for defect in parent_defects:
-            new_defect = URIRef(defect.toPython())
-        
+            new_defect, defect_triples = self.graph.iterate_and_rename_triples(defect)
+            #add the new defect to the new material
+            self.graph.add((material, CMSO.hasDefect, new_defect))
+            #add the triples to the graph
+            for triple in defect_triples:
+                self.graph.add((triple))        

--- a/atomrdf/structure.py
+++ b/atomrdf/structure.py
@@ -2553,3 +2553,18 @@ class System(pc.System):
             self.graph.add((plane_vector, CMSO.hasComponent_y, Literal(plane[1], datatype=XSD.float),))
             self.graph.add((plane_vector, CMSO.hasComponent_z, Literal(plane[2], datatype=XSD.float),))
             self.graph.add((activity, UNSAFECMSO.hasDistance, Literal(distance, datatype=XSD.float)))
+
+    def copy_defects(self, parent_sample):
+        if self.sample is None:
+            return
+        if parent_sample is None:
+            return
+        
+        parent_material = list([k[2] for k in self.kg.triples((parent_sample, CMSO.hasMaterial, None))])[0]
+        parent_defects = list([x[2] for x in self.kg.triples((parent_material, CMSO.hasDefect, None))])
+
+        material = list([k[2] for k in self.kg.triples((self.sample, CMSO.hasMaterial, None))])[0]
+
+        for defect in parent_defects:
+            new_defect = URIRef(defect.toPython())
+        

--- a/atomrdf/structure.py
+++ b/atomrdf/structure.py
@@ -527,11 +527,12 @@ def _make_grain_boundary_aimsgb(
                 to_primitive=primitive,
             )
     asestruct = AseAtomsAdaptor().get_atoms(structure=gb_struct)
-    sys = System.read.ase(asestruct, graph=graph, names=names, label=label)
+    sys = System.read.ase(asestruct, graph=None, names=names, label=label)
     sys.atoms._lattice = structure
     sys.atoms._lattice_constant = _declass(lattice_constant)
     sys._structure_dict = sdict
     sys.label = label
+    sys.graph = graph
     sys.to_graph()
     sys.add_property_mappings(lattice_constant, mapping_quantity='lattice_constant')
     sys.add_property_mappings(ca_ratio, mapping_quantity='lattice_constant')
@@ -619,13 +620,14 @@ def _make_grain_boundary_inbuilt(
     if 'repetitions' not in sdict.keys():
         sdict['repetitions'] = repetitions
     
-    s = System(graph=graph, names=names)
+    s = System(graph=None, names=names)
     s.box = box
     s.atoms = atoms
     s.atoms._lattice = structure
     s.atoms._lattice_constant = _declass(lattice_constant)
     s._structure_dict = sdict
     s.label = label
+    s.graph = graph
     s.to_graph()
     s.add_property_mappings(lattice_constant, mapping_quantity='lattice_constant')
     

--- a/atomrdf/structure.py
+++ b/atomrdf/structure.py
@@ -2562,10 +2562,10 @@ class System(pc.System):
         if parent_sample is None:
             return
         
-        parent_material = list([k[2] for k in self.kg.triples((parent_sample, CMSO.hasMaterial, None))])[0]
-        parent_defects = list([x[2] for x in self.kg.triples((parent_material, CMSO.hasDefect, None))])
+        parent_material = list([k[2] for k in self.graph.triples((parent_sample, CMSO.hasMaterial, None))])[0]
+        parent_defects = list([x[2] for x in self.graph.triples((parent_material, CMSO.hasDefect, None))])
 
-        material = list([k[2] for k in self.kg.triples((self.sample, CMSO.hasMaterial, None))])[0]
+        material = list([k[2] for k in self.graph.triples((self.sample, CMSO.hasMaterial, None))])[0]
 
         for defect in parent_defects:
             new_defect, defect_triples = self.graph.iterate_and_rename_triples(defect)

--- a/atomrdf/structure.py
+++ b/atomrdf/structure.py
@@ -2568,17 +2568,4 @@ class System(pc.System):
             return
         if parent_sample is None:
             return
-        
-        parent_material = list([k[2] for k in self.graph.triples((parent_sample, CMSO.hasMaterial, None))])[0]
-        parent_defects = list([x[2] for x in self.graph.triples((parent_material, CMSO.hasDefect, None))])
-
-        material = list([k[2] for k in self.graph.triples((self.sample, CMSO.hasMaterial, None))])[0]
-
-        for defect in parent_defects:
-            new_defect, defect_triples = self.graph.iterate_and_rename_triples(defect)
-            #add the new defect to the new material
-            self.graph.add((material, CMSO.hasDefect, new_defect))
-            #add the triples to the graph
-            for triple in defect_triples:
-                #print(triple)
-                self.graph.add(triple)        
+        self.graph.copy_defects(self.sample, parent_sample)

--- a/atomrdf/workflow/workflow.py
+++ b/atomrdf/workflow/workflow.py
@@ -207,49 +207,11 @@ class Workflow:
     ):
         # Here we need to add inherited info: CalculatedProperties will be lost
         # Defects will be inherited
+
         if sample is None:
             return
 
-        parent_material = list(
-            [
-                k[2]
-                for k in self.kg.triples((parent_sample, CMSO.hasMaterial, None))
-            ]
-        )[0]
-        parent_defects = list(
-            [x[2] for x in self.kg.triples((parent_material, CMSO.hasDefect, None))]
-        )
-        # now for each defect we copy add this to the final sample
-        material = list(
-            [k[2] for k in self.kg.triples((sample, CMSO.hasMaterial, None))]
-        )[0]
-
-        for defect in parent_defects:
-            new_defect = URIRef(defect.toPython())
-            self.kg.add((material, CMSO.hasDefect, new_defect))
-            # now fetch all defect based info
-            for triple in self.kg.triples((defect, None, None)):
-                self.kg.add((new_defect, triple[1], triple[2]))
-
-        # now add the special props for vacancy, interstitial &substitional
-        for triple in self.kg.triples(
-            (parent_sample, PODO.hasVacancyConcentration, None)
-        ):
-            self.kg.add((sample, triple[1], triple[2]))
-        for triple in self.kg.triples(
-            (parent_sample, PODO.hasNumberOfVacancies, None)
-        ):
-            self.kg.add((sample, triple[1], triple[2]))
-        for triple in self.kg.triples(
-            (parent_sample, PODO.hasImpurityConcentration, None)
-        ):
-            self.kg.add((sample, triple[1], triple[2]))
-        for triple in self.kg.triples(
-            (parent_sample, PODO.hasNumberOfImpurityAtoms, None)
-        ):
-            self.kg.add((sample, triple[1], triple[2]))
-
-
+        self.kg.copy_defects(sample, parent_sample)
 
     def _add_method(
             self, job_dict, 

--- a/examples/02_grain_boundaries.ipynb
+++ b/examples/02_grain_boundaries.ipynb
@@ -61,6 +61,78 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "dc65fb07",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from atomrdf.namespace import PROV, CMSO\n",
+    "parent_material = list(\n",
+    "    [\n",
+    "        k[2]\n",
+    "        for k in kg.triples((struct_gb_1.sample, CMSO.hasMaterial, None))\n",
+    "    ]\n",
+    ")[0]\n",
+    "parent_defects = list(\n",
+    "    [x[2] for x in kg.triples((parent_material, CMSO.hasDefect, None))]\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "2f07ae38",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[rdflib.term.URIRef('sample:ddb98ea8-c0dd-4b86-b6a1-97bddf93b94a_SymmetricalTiltGrainBoundary')]"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "parent_defects"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "6f2b8588",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "sample:ddb98ea8-c0dd-4b86-b6a1-97bddf93b94a_SymmetricalTiltGrainBoundary\n",
+      "sample:ddb98ea8-c0dd-4b86-b6a1-97bddf93b94a_SymmetricalTiltGrainBoundary\n",
+      "sample:ddb98ea8-c0dd-4b86-b6a1-97bddf93b94a_SymmetricalTiltGrainBoundary\n",
+      "sample:ddb98ea8-c0dd-4b86-b6a1-97bddf93b94a_SymmetricalTiltGrainBoundary\n",
+      "sample:ddb98ea8-c0dd-4b86-b6a1-97bddf93b94a_SymmetricalTiltGrainBoundary\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'sample:ddb98ea8-c0dd-4b86-b6a1-97bddf93b94a_SymmetricalTiltGrainBoundary': None}"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "kg.iterate_and_reapply_triples(parent_defects[0])"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "717626e5-3672-470e-a9d9-2878310268ca",
    "metadata": {},

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as readme_file:
 
 setup(
     name='atomrdf',
-    version='0.9.10',
+    version='0.9.11',
     author='Abril Azocar Guzman, Sarath Menon',
     author_email='sarath.menon@pyscal.org',
     description='Ontology based structural manipulation and quering',

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -91,3 +91,22 @@ def test_interstitials():
 	species = s.value(sys.sample, CMSO.hasSpecies)
 	elements = [k[2] for k in s.triples((species, CMSO.hasElement, None))]
 	assert len(elements) == 3
+
+def test_gb():
+	kg = KnowledgeGraph()
+	struct_gb_1 = System.create.defect.grain_boundary(axis=[0,0,1], 
+                        sigma=5, 
+                        gb_plane=[3, -1, 0],
+                        element='Fe',
+                        graph=kg)
+	res = kg.query_sample(kg.ontology.terms.pldo.SymmetricalTiltGrainBoundary)
+	assert len(res.AtomicScaleSample.values) == 1
+	
+	new = struct_gb_1.repeat((2,2,2))
+	res = kg.query_sample(kg.ontology.terms.pldo.SymmetricalTiltGrainBoundary)
+	assert len(res.AtomicScaleSample.values) == 2
+
+	ss = kg.get_sample(new.sample)
+	res = ss.query_sample(ss.ontology.terms.pldo.SymmetricalTiltGrainBoundary)
+	assert len(res.AtomicScaleSample.values) == 1
+


### PR DESCRIPTION
will close #158 

- [x] generalise extract triples
- [x] stop extract triples at derived samples
- [x] add a new function to create graph from triples
- [x] modify the get_sample function to work with new setup
- [x] add function to create new IDs for URIRefs in the extracted graph
- [x] add function to delete the extracted triples (could be used for removing a sample) (will do in new PR)
- [x] add copy_defects which copy defect triples to a new structure
- [x] use this function in workflow.py
- [x] use this function for all modify methods