### PR TITLE
Change `repetitions` to `[1, 1, 1]` if `None`

### DIFF
--- a/atomrdf/structure.py
+++ b/atomrdf/structure.py
@@ -94,6 +94,8 @@ def _make_crystal(
     s : object
         The atomrdf.Structure object representing the generated crystal structure.
     """
+    if repetitions is None:
+        repetitions = [1, 1, 1]
     atoms, box, sdict = pcs.make_crystal(
         structure,
         lattice_constant = _declass(lattice_constant),

--- a/atomrdf/structure.py
+++ b/atomrdf/structure.py
@@ -2676,4 +2676,3 @@ class System(pc.System):
         ase_structure = self.write.ase()
         pyiron_structure = ase_to_pyiron(ase_structure)
         return pyiron_structure.plot3d(*args, **kwargs)
-    


### PR DESCRIPTION
Otherwise [`01_getting_started.ipynb`](https://github.com/pyscal/atomRDF/blob/main/examples/01_getting_started.ipynb) fails.

I didn't add a line at the end. Apparently GitHub did...