### PR TITLE
Fix terms

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.9.20
+current_version = 0.10.0
 commit = True
 tag = False
 

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ wf*
 *.in
 *.dot
 *.png
+examples/workflow_examples/t*
+examples/workflow_examples/y*
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -19,4 +19,4 @@ url: 'https://atomrdf.pyscal.org'
 license: "MIT"
 repository-code: https://github.com/pyscal/atomRDF
 type: software
-version: 0.9.20
+version: 0.10.0

--- a/atomrdf/__init__.py
+++ b/atomrdf/__init__.py
@@ -1,3 +1,3 @@
-from atomrdf.graph import KnowledgeGraph
-from atomrdf.structure import System
-from atomrdf.workflow.workflow import Workflow
+#from atomrdf.graph import KnowledgeGraph
+#from atomrdf.structure import System
+#from atomrdf.workflow.workflow import Workflow

--- a/atomrdf/__init__.py
+++ b/atomrdf/__init__.py
@@ -1,3 +1,3 @@
-#from atomrdf.graph import KnowledgeGraph
-#from atomrdf.structure import System
-#from atomrdf.workflow.workflow import Workflow
+from atomrdf.graph import KnowledgeGraph
+from atomrdf.structure import System
+from atomrdf.workflow.workflow import Workflow

--- a/atomrdf/data/asmo.owl
+++ b/atomrdf/data/asmo.owl
@@ -398,9 +398,10 @@ f(x) = 1/(√(2 π) σ) e^-((x - μ)^2/(2 σ^2))</obo:IAO_0000112>
     <!-- http://purls.helmholtz-metadaten.de/asmo/hasInputParameter -->
 
     <owl:ObjectProperty rdf:about="http://purls.helmholtz-metadaten.de/asmo/hasInputParameter">
-        <rdfs:domain rdf:resource="http://purls.helmholtz-metadaten.de/asmo/EnergyCalculation"/>
+        <rdfs:subPropertyOf rdf:resource="http://purls.helmholtz-metadaten.de/asmo/hasSimulationParameter"/>
+        <rdfs:domain rdf:resource="http://purls.helmholtz-metadaten.de/asmo/Simulation"/>
         <rdfs:range rdf:resource="http://purls.helmholtz-metadaten.de/asmo/InputParameter"/>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The relation between an Energy Calculation activity and the input parameters used.</obo:IAO_0000115>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The relation between a Simulation activity and the input parameters used.</obo:IAO_0000115>
         <rdfs:label>has input parameter</rdfs:label>
     </owl:ObjectProperty>
     
@@ -417,6 +418,27 @@ f(x) = 1/(√(2 π) σ) e^-((x - μ)^2/(2 σ^2))</obo:IAO_0000112>
     
 
 
+    <!-- http://purls.helmholtz-metadaten.de/asmo/hasOutputParameter -->
+
+    <owl:ObjectProperty rdf:about="http://purls.helmholtz-metadaten.de/asmo/hasOutputParameter">
+        <rdfs:subPropertyOf rdf:resource="http://purls.helmholtz-metadaten.de/asmo/hasSimulationParameter"/>
+        <rdfs:domain rdf:resource="http://purls.helmholtz-metadaten.de/asmo/Simulation"/>
+        <rdfs:range rdf:resource="http://purls.helmholtz-metadaten.de/asmo/OutputParameter"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has output parameter</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purls.helmholtz-metadaten.de/asmo/hasPlane -->
+
+    <owl:ObjectProperty rdf:about="http://purls.helmholtz-metadaten.de/asmo/hasPlane">
+        <rdfs:domain rdf:resource="http://purls.helmholtz-metadaten.de/asmo/Shear"/>
+        <rdfs:range rdf:resource="http://purls.helmholtz-metadaten.de/cmso/Plane"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has plane</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
     <!-- http://purls.helmholtz-metadaten.de/asmo/hasRelaxationDOF -->
 
     <owl:ObjectProperty rdf:about="http://purls.helmholtz-metadaten.de/asmo/hasRelaxationDOF">
@@ -424,6 +446,23 @@ f(x) = 1/(√(2 π) σ) e^-((x - μ)^2/(2 σ^2))</obo:IAO_0000112>
         <rdfs:range rdf:resource="http://purls.helmholtz-metadaten.de/asmo/RelaxationDOF"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The relation between an Energy Calculation activity and the relaxation degrees of freedom set as constraints in the calculation.</obo:IAO_0000115>
         <rdfs:label>has relaxation DOF</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purls.helmholtz-metadaten.de/asmo/hasSimulationParameter -->
+
+    <owl:ObjectProperty rdf:about="http://purls.helmholtz-metadaten.de/asmo/hasSimulationParameter">
+        <rdfs:domain rdf:resource="http://purls.helmholtz-metadaten.de/asmo/Simulation"/>
+        <rdfs:range>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purls.helmholtz-metadaten.de/asmo/PhysicalQuantity"/>
+                    <rdf:Description rdf:about="http://purls.helmholtz-metadaten.de/asmo/SimulationParameter"/>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:range>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has simulation parameter</rdfs:label>
     </owl:ObjectProperty>
     
 
@@ -442,9 +481,17 @@ f(x) = 1/(√(2 π) σ) e^-((x - μ)^2/(2 σ^2))</obo:IAO_0000112>
     <!-- http://purls.helmholtz-metadaten.de/asmo/hasUnit -->
 
     <owl:ObjectProperty rdf:about="http://purls.helmholtz-metadaten.de/asmo/hasUnit">
-        <rdfs:domain rdf:resource="http://purls.helmholtz-metadaten.de/asmo/InputParameter"/>
+        <rdfs:domain>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purls.helmholtz-metadaten.de/asmo/PhysicalQuantity"/>
+                    <rdf:Description rdf:about="http://purls.helmholtz-metadaten.de/asmo/SimulationParameter"/>
+                    <rdf:Description rdf:about="http://purls.helmholtz-metadaten.de/cmso/CalculatedProperty"/>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:domain>
         <rdfs:range rdf:resource="http://qudt.org/schema/qudt/Unit"/>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The relation between the input parameter set and the unit of the quantity. (e.g. eV for energy cutoff)</obo:IAO_0000115>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The relation between an entity and the unit of the quantity. (e.g. eV for energy cutoff)</obo:IAO_0000115>
         <rdfs:label>has unit</rdfs:label>
     </owl:ObjectProperty>
     
@@ -457,6 +504,24 @@ f(x) = 1/(√(2 π) σ) e^-((x - μ)^2/(2 σ^2))</obo:IAO_0000112>
         <rdfs:range rdf:resource="http://www.w3.org/ns/prov#Activity"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The relation between a calculated property and the activity through which it was obtained.</obo:IAO_0000115>
         <rdfs:label>was calculated by</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purls.helmholtz-metadaten.de/cmso/hasVector -->
+
+    <owl:ObjectProperty rdf:about="http://purls.helmholtz-metadaten.de/cmso/hasVector">
+        <rdfs:domain>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purls.helmholtz-metadaten.de/asmo/SpatialTransformation"/>
+                    <rdf:Description rdf:about="http://purls.helmholtz-metadaten.de/cmso/SimulationCell"/>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:domain>
+        <rdfs:range rdf:resource="http://purls.helmholtz-metadaten.de/cmso/Vector"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The relation between an entity and its vectors.</obo:IAO_0000115>
+        <rdfs:label>has vector</rdfs:label>
     </owl:ObjectProperty>
     
 
@@ -655,21 +720,6 @@ prov:wasInfluencedBy should not be used without also using one of its subpropert
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://www.w3.org/ns/prov#wasInfluencedBy"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#range"/>
-        <owl:annotatedTarget>
-            <owl:Class>
-                <owl:unionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://www.w3.org/ns/prov#Activity"/>
-                    <rdf:Description rdf:about="http://www.w3.org/ns/prov#Agent"/>
-                    <rdf:Description rdf:about="http://www.w3.org/ns/prov#Entity"/>
-                </owl:unionOf>
-            </owl:Class>
-        </owl:annotatedTarget>
-        <prov:definition>influencer: an identifier (o1) for an ancestor entity, activity, or agent that the former depends on;</prov:definition>
-        <prov:dm>http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-influence</prov:dm>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://www.w3.org/ns/prov#wasInfluencedBy"/>
         <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#domain"/>
         <owl:annotatedTarget>
             <owl:Class>
@@ -681,6 +731,21 @@ prov:wasInfluencedBy should not be used without also using one of its subpropert
             </owl:Class>
         </owl:annotatedTarget>
         <prov:definition>influencee: an identifier (o2) for an entity, activity, or agent; </prov:definition>
+        <prov:dm>http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-influence</prov:dm>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://www.w3.org/ns/prov#wasInfluencedBy"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#range"/>
+        <owl:annotatedTarget>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://www.w3.org/ns/prov#Activity"/>
+                    <rdf:Description rdf:about="http://www.w3.org/ns/prov#Agent"/>
+                    <rdf:Description rdf:about="http://www.w3.org/ns/prov#Entity"/>
+                </owl:unionOf>
+            </owl:Class>
+        </owl:annotatedTarget>
+        <prov:definition>influencer: an identifier (o1) for an ancestor entity, activity, or agent that the former depends on;</prov:definition>
         <prov:dm>http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-influence</prov:dm>
     </owl:Axiom>
     
@@ -837,15 +902,6 @@ prov:wasInfluencedBy should not be used without also using one of its subpropert
     
 
 
-    <!-- http://purls.helmholtz-metadaten.de/asmo/hasValue -->
-
-    <owl:DatatypeProperty rdf:about="http://purls.helmholtz-metadaten.de/asmo/hasValue">
-        <obo:IAO_0000115>A data property linking an input parameter with the value set.</obo:IAO_0000115>
-        <rdfs:label>has value</rdfs:label>
-    </owl:DatatypeProperty>
-    
-
-
     <!-- http://purls.helmholtz-metadaten.de/cmso/hasReference -->
 
     <owl:DatatypeProperty rdf:about="http://purls.helmholtz-metadaten.de/cmso/hasReference">
@@ -853,6 +909,25 @@ prov:wasInfluencedBy should not be used without also using one of its subpropert
         <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
         <obo:IAO_0000115>A data property linking an entity with a reference (e.g. bibliographic) to another resource.</obo:IAO_0000115>
         <rdfs:label>has reference</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://purls.helmholtz-metadaten.de/cmso/hasValue -->
+
+    <owl:DatatypeProperty rdf:about="http://purls.helmholtz-metadaten.de/cmso/hasValue">
+        <rdfs:domain>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purls.helmholtz-metadaten.de/asmo/PhysicalQuantity"/>
+                    <rdf:Description rdf:about="http://purls.helmholtz-metadaten.de/asmo/SimulationParameter"/>
+                    <rdf:Description rdf:about="http://purls.helmholtz-metadaten.de/cmso/CalculatedProperty"/>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:domain>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#float"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A data property linking an entity to its value.</obo:IAO_0000115>
+        <rdfs:label>has value</rdfs:label>
     </owl:DatatypeProperty>
     
 
@@ -924,6 +999,22 @@ prov:wasInfluencedBy should not be used without also using one of its subpropert
     
 
 
+    <!-- http://purls.helmholtz-metadaten.de/asmo/Barostat -->
+
+    <owl:Class rdf:about="http://purls.helmholtz-metadaten.de/asmo/Barostat">
+        <rdfs:subClassOf rdf:resource="http://purls.helmholtz-metadaten.de/asmo/InputParameter"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purls.helmholtz-metadaten.de/asmo/BulkModulus -->
+
+    <owl:Class rdf:about="http://purls.helmholtz-metadaten.de/asmo/BulkModulus">
+        <rdfs:subClassOf rdf:resource="http://purls.helmholtz-metadaten.de/cmso/CalculatedProperty"/>
+    </owl:Class>
+    
+
+
     <!-- http://purls.helmholtz-metadaten.de/asmo/ComputationalMethod -->
 
     <owl:Class rdf:about="http://purls.helmholtz-metadaten.de/asmo/ComputationalMethod">
@@ -968,6 +1059,15 @@ prov:wasInfluencedBy should not be used without also using one of its subpropert
     
 
 
+    <!-- http://purls.helmholtz-metadaten.de/asmo/Energy -->
+
+    <owl:Class rdf:about="http://purls.helmholtz-metadaten.de/asmo/Energy">
+        <rdfs:subClassOf rdf:resource="http://purls.helmholtz-metadaten.de/asmo/PhysicalQuantity"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Energy</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://purls.helmholtz-metadaten.de/asmo/EnergyCalculation -->
 
     <owl:Class rdf:about="http://purls.helmholtz-metadaten.de/asmo/EnergyCalculation">
@@ -975,6 +1075,15 @@ prov:wasInfluencedBy should not be used without also using one of its subpropert
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Energy calculation is an activity where the energy of the system is computed within the given optimization constraints.</obo:IAO_0000115>
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This activity does not specify the way the energy is calculated, it can be used to refer to a rigid calculation or also to energy minimization or optimization. See RelaxationDOF class for specifics about the constraints.</rdfs:comment>
         <rdfs:label>Energy Calculation</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purls.helmholtz-metadaten.de/asmo/EnergyCutoff -->
+
+    <owl:Class rdf:about="http://purls.helmholtz-metadaten.de/asmo/EnergyCutoff">
+        <rdfs:subClassOf rdf:resource="http://purls.helmholtz-metadaten.de/asmo/InputParameter"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Energy Cutoff</rdfs:label>
     </owl:Class>
     
 
@@ -991,10 +1100,20 @@ prov:wasInfluencedBy should not be used without also using one of its subpropert
     
 
 
+    <!-- http://purls.helmholtz-metadaten.de/asmo/FreeEnergy -->
+
+    <owl:Class rdf:about="http://purls.helmholtz-metadaten.de/asmo/FreeEnergy">
+        <rdfs:subClassOf rdf:resource="http://purls.helmholtz-metadaten.de/asmo/Energy"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Free Energy</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://purls.helmholtz-metadaten.de/asmo/InputParameter -->
 
     <owl:Class rdf:about="http://purls.helmholtz-metadaten.de/asmo/InputParameter">
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Input Parameter are the parameters provided as input to the software tool performing the numerical calculations.</obo:IAO_0000115>
+        <rdfs:subClassOf rdf:resource="http://purls.helmholtz-metadaten.de/asmo/SimulationParameter"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Input Parameter is a parameter provided as input to the software tool performing the numerical calculations.</obo:IAO_0000115>
         <rdfs:label>Input Parameter</rdfs:label>
     </owl:Class>
     
@@ -1010,6 +1129,24 @@ prov:wasInfluencedBy should not be used without also using one of its subpropert
     
 
 
+    <!-- http://purls.helmholtz-metadaten.de/asmo/KPointMesh -->
+
+    <owl:Class rdf:about="http://purls.helmholtz-metadaten.de/asmo/KPointMesh">
+        <rdfs:subClassOf rdf:resource="http://purls.helmholtz-metadaten.de/asmo/InputParameter"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">KPoint Mesh</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purls.helmholtz-metadaten.de/asmo/KineticEnergy -->
+
+    <owl:Class rdf:about="http://purls.helmholtz-metadaten.de/asmo/KineticEnergy">
+        <rdfs:subClassOf rdf:resource="http://purls.helmholtz-metadaten.de/asmo/Energy"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Kinetic Energy</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://purls.helmholtz-metadaten.de/asmo/KineticMonteCarloMethod -->
 
     <owl:Class rdf:about="http://purls.helmholtz-metadaten.de/asmo/KineticMonteCarloMethod">
@@ -1017,6 +1154,15 @@ prov:wasInfluencedBy should not be used without also using one of its subpropert
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Kinetic Monte Carlo Method is a variation of the Monte Carlo method, intended to simulate the time evolution of a process with known transition rates among states.</obo:IAO_0000115>
         <rdfs:label>Kinetic Monte Carlo Method</rdfs:label>
         <skos:altLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kMC</skos:altLabel>
+    </owl:Class>
+    
+
+
+    <!-- http://purls.helmholtz-metadaten.de/asmo/Length -->
+
+    <owl:Class rdf:about="http://purls.helmholtz-metadaten.de/asmo/Length">
+        <rdfs:subClassOf rdf:resource="http://purls.helmholtz-metadaten.de/asmo/PhysicalQuantity"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Length</rdfs:label>
     </owl:Class>
     
 
@@ -1045,6 +1191,15 @@ prov:wasInfluencedBy should not be used without also using one of its subpropert
         <rdfs:label>Machine Learning Potential</rdfs:label>
         <skos:altLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MLIP</skos:altLabel>
         <skos:altLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MLP</skos:altLabel>
+    </owl:Class>
+    
+
+
+    <!-- http://purls.helmholtz-metadaten.de/asmo/Mass -->
+
+    <owl:Class rdf:about="http://purls.helmholtz-metadaten.de/asmo/Mass">
+        <rdfs:subClassOf rdf:resource="http://purls.helmholtz-metadaten.de/asmo/PhysicalQuantity"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mass</rdfs:label>
     </owl:Class>
     
 
@@ -1132,12 +1287,66 @@ prov:wasInfluencedBy should not be used without also using one of its subpropert
     
 
 
+    <!-- http://purls.helmholtz-metadaten.de/asmo/NumberOfIonicSteps -->
+
+    <owl:Class rdf:about="http://purls.helmholtz-metadaten.de/asmo/NumberOfIonicSteps">
+        <rdfs:subClassOf rdf:resource="http://purls.helmholtz-metadaten.de/asmo/OutputParameter"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Number Of Ionic Steps</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purls.helmholtz-metadaten.de/asmo/OutputParameter -->
+
+    <owl:Class rdf:about="http://purls.helmholtz-metadaten.de/asmo/OutputParameter">
+        <rdfs:subClassOf rdf:resource="http://purls.helmholtz-metadaten.de/asmo/SimulationParameter"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Output Parameter is a parameter resulting from a software tool performing the numerical calculations.</obo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Output Parameter</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purls.helmholtz-metadaten.de/asmo/PeriodicBoundaryCondition -->
+
+    <owl:Class rdf:about="http://purls.helmholtz-metadaten.de/asmo/PeriodicBoundaryCondition">
+        <rdfs:subClassOf rdf:resource="http://purls.helmholtz-metadaten.de/asmo/InputParameter"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Periodic Boundary Condition</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purls.helmholtz-metadaten.de/asmo/PhysicalQuantity -->
+
+    <owl:Class rdf:about="http://purls.helmholtz-metadaten.de/asmo/PhysicalQuantity">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Physical Quantity</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://purls.helmholtz-metadaten.de/asmo/PointDefectCreation -->
 
     <owl:Class rdf:about="http://purls.helmholtz-metadaten.de/asmo/PointDefectCreation">
         <rdfs:subClassOf rdf:resource="http://purls.helmholtz-metadaten.de/asmo/StructureManipulation"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Point defect creation is a type of structure manipulation to introduce a point defect, i.e. add, delete or substitute atoms.</obo:IAO_0000115>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Point Defect Creation</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purls.helmholtz-metadaten.de/asmo/PotentialEnergy -->
+
+    <owl:Class rdf:about="http://purls.helmholtz-metadaten.de/asmo/PotentialEnergy">
+        <rdfs:subClassOf rdf:resource="http://purls.helmholtz-metadaten.de/asmo/Energy"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Potential Energy</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purls.helmholtz-metadaten.de/asmo/Pressure -->
+
+    <owl:Class rdf:about="http://purls.helmholtz-metadaten.de/asmo/Pressure">
+        <rdfs:subClassOf rdf:resource="http://purls.helmholtz-metadaten.de/asmo/PhysicalQuantity"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pressure</rdfs:label>
     </owl:Class>
     
 
@@ -1187,6 +1396,33 @@ prov:wasInfluencedBy should not be used without also using one of its subpropert
         <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/prov#Activity"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">In computational materials science, a simulation refers to the production of a computer model of a material system, for the purpose of imitating a process over time.</obo:IAO_0000115>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Simulation</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purls.helmholtz-metadaten.de/asmo/SimulationCellLength -->
+
+    <owl:Class rdf:about="http://purls.helmholtz-metadaten.de/asmo/SimulationCellLength">
+        <rdfs:subClassOf rdf:resource="http://purls.helmholtz-metadaten.de/asmo/Length"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Simulation Cell Length</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purls.helmholtz-metadaten.de/asmo/SimulationParameter -->
+
+    <owl:Class rdf:about="http://purls.helmholtz-metadaten.de/asmo/SimulationParameter">
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Simulation parameter is a parameter for a software tool to perform numerical calculations.</obo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Simulation Parameter</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purls.helmholtz-metadaten.de/asmo/SimulationTime -->
+
+    <owl:Class rdf:about="http://purls.helmholtz-metadaten.de/asmo/SimulationTime">
+        <rdfs:subClassOf rdf:resource="http://purls.helmholtz-metadaten.de/asmo/Time"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Simulation Time</rdfs:label>
     </owl:Class>
     
 
@@ -1244,11 +1480,65 @@ prov:wasInfluencedBy should not be used without also using one of its subpropert
     
 
 
+    <!-- http://purls.helmholtz-metadaten.de/asmo/Temperature -->
+
+    <owl:Class rdf:about="http://purls.helmholtz-metadaten.de/asmo/Temperature">
+        <rdfs:subClassOf rdf:resource="http://purls.helmholtz-metadaten.de/asmo/PhysicalQuantity"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Temperature</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://purls.helmholtz-metadaten.de/asmo/ThermodynamicIntegration -->
 
     <owl:Class rdf:about="http://purls.helmholtz-metadaten.de/asmo/ThermodynamicIntegration">
         <rdfs:subClassOf rdf:resource="http://purls.helmholtz-metadaten.de/asmo/Simulation"/>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Thermodynamic Integration</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purls.helmholtz-metadaten.de/asmo/Thermostat -->
+
+    <owl:Class rdf:about="http://purls.helmholtz-metadaten.de/asmo/Thermostat">
+        <rdfs:subClassOf rdf:resource="http://purls.helmholtz-metadaten.de/asmo/InputParameter"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Thermostat</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purls.helmholtz-metadaten.de/asmo/Time -->
+
+    <owl:Class rdf:about="http://purls.helmholtz-metadaten.de/asmo/Time">
+        <rdfs:subClassOf rdf:resource="http://purls.helmholtz-metadaten.de/asmo/PhysicalQuantity"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Time</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purls.helmholtz-metadaten.de/asmo/TimeStep -->
+
+    <owl:Class rdf:about="http://purls.helmholtz-metadaten.de/asmo/TimeStep">
+        <rdfs:subClassOf rdf:resource="http://purls.helmholtz-metadaten.de/asmo/InputParameter"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Time Step</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purls.helmholtz-metadaten.de/asmo/TotalEnergy -->
+
+    <owl:Class rdf:about="http://purls.helmholtz-metadaten.de/asmo/TotalEnergy">
+        <rdfs:subClassOf rdf:resource="http://purls.helmholtz-metadaten.de/asmo/Energy"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Total Energy</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purls.helmholtz-metadaten.de/asmo/TotalMagneticMoment -->
+
+    <owl:Class rdf:about="http://purls.helmholtz-metadaten.de/asmo/TotalMagneticMoment">
+        <rdfs:subClassOf rdf:resource="http://purls.helmholtz-metadaten.de/cmso/CalculatedProperty"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Total Magnetic Moment</rdfs:label>
     </owl:Class>
     
 
@@ -1263,11 +1553,60 @@ prov:wasInfluencedBy should not be used without also using one of its subpropert
     
 
 
+    <!-- http://purls.helmholtz-metadaten.de/asmo/Volume -->
+
+    <owl:Class rdf:about="http://purls.helmholtz-metadaten.de/asmo/Volume">
+        <rdfs:subClassOf rdf:resource="http://purls.helmholtz-metadaten.de/asmo/PhysicalQuantity"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Volume</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purls.helmholtz-metadaten.de/asmo/VolumeRange -->
+
+    <owl:Class rdf:about="http://purls.helmholtz-metadaten.de/asmo/VolumeRange">
+        <rdfs:subClassOf rdf:resource="http://purls.helmholtz-metadaten.de/asmo/InputParameter"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Volume Range</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://purls.helmholtz-metadaten.de/cmso/CalculatedProperty -->
 
     <owl:Class rdf:about="http://purls.helmholtz-metadaten.de/cmso/CalculatedProperty">
         <rdfs:label>Calculated Property</rdfs:label>
         <skos:definition>A calculated property is a property of a material resulting from a calculation or simulation.</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://purls.helmholtz-metadaten.de/cmso/Plane -->
+
+    <owl:Class rdf:about="http://purls.helmholtz-metadaten.de/cmso/Plane">
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">In mathematics, a plane is a two-dimensional space or flat surface that extends indefinitely.</obo:IAO_0000115>
+        <obo:OBCS_0000221 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">𝑎 𝑥 + 𝑏 𝑦 + 𝑐 𝑧 + 𝑑 = 0</obo:OBCS_0000221>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The equation of a plane is 𝑎 𝑥 + 𝑏 𝑦 + 𝑐 𝑧 + 𝑑 = 0 , where 𝑎 , 𝑏 , and 𝑐 are the components of the normal vector ⃑ 𝑛 = ( 𝑎 , 𝑏 , 𝑐 ) , which is perpendicular to the plane or any vector parallel to the plane.</rdfs:comment>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Plane</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purls.helmholtz-metadaten.de/cmso/SimulationCell -->
+
+    <owl:Class rdf:about="http://purls.helmholtz-metadaten.de/cmso/SimulationCell">
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A simulation cell is a representation of the structure or system to be simulated. It is often a three-dimensional box (although not necessarily), where information about the crystal structure and material is contained.</obo:IAO_0000115>
+        <rdfs:label>Simulation Cell</rdfs:label>
+        <skos:altLabel>Box</skos:altLabel>
+        <skos:altLabel>Supercell</skos:altLabel>
+    </owl:Class>
+    
+
+
+    <!-- http://purls.helmholtz-metadaten.de/cmso/Vector -->
+
+    <owl:Class rdf:about="http://purls.helmholtz-metadaten.de/cmso/Vector">
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Vector is a quantity that has a magnitude and direction.</obo:IAO_0000115>
+        <rdfs:label>Vector</rdfs:label>
     </owl:Class>
     
 
@@ -1485,12 +1824,31 @@ prov:wasInfluencedBy should not be used without also using one of its subpropert
     
 
 
+    <!-- http://purls.helmholtz-metadaten.de/asmo/Andersen -->
+
+    <owl:NamedIndividual rdf:about="http://purls.helmholtz-metadaten.de/asmo/Andersen">
+        <rdf:type rdf:resource="http://purls.helmholtz-metadaten.de/asmo/Barostat"/>
+        <rdf:type rdf:resource="http://purls.helmholtz-metadaten.de/asmo/Thermostat"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Andersen</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
     <!-- http://purls.helmholtz-metadaten.de/asmo/AtomicPositionRelaxation -->
 
     <owl:NamedIndividual rdf:about="http://purls.helmholtz-metadaten.de/asmo/AtomicPositionRelaxation">
         <rdf:type rdf:resource="http://purls.helmholtz-metadaten.de/asmo/RelaxationDOF"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Atomic positions are allowed to change in the calculation.</obo:IAO_0000115>
         <rdfs:label>Atomic Position Relaxation</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purls.helmholtz-metadaten.de/asmo/Berendsen -->
+
+    <owl:NamedIndividual rdf:about="http://purls.helmholtz-metadaten.de/asmo/Berendsen">
+        <rdf:type rdf:resource="http://purls.helmholtz-metadaten.de/asmo/Barostat"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Berendsen</rdfs:label>
     </owl:NamedIndividual>
     
 
@@ -1503,6 +1861,15 @@ prov:wasInfluencedBy should not be used without also using one of its subpropert
         <obo:IAO_0000119 rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://doi.org/10.1103/PhysRev.71.809</obo:IAO_0000119>
         <obo:IAO_0000119 rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://en.wikipedia.org/wiki/Birch%E2%80%93Murnaghan_equation_of_state</obo:IAO_0000119>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Birch-Murnaghan</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purls.helmholtz-metadaten.de/asmo/BussiDonadioParrinello -->
+
+    <owl:NamedIndividual rdf:about="http://purls.helmholtz-metadaten.de/asmo/BussiDonadioParrinello">
+        <rdf:type rdf:resource="http://purls.helmholtz-metadaten.de/asmo/Thermostat"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bussi-Donadio-Parrinello</rdfs:label>
     </owl:NamedIndividual>
     
 
@@ -1585,6 +1952,15 @@ prov:wasInfluencedBy should not be used without also using one of its subpropert
     
 
 
+    <!-- http://purls.helmholtz-metadaten.de/asmo/Langevin -->
+
+    <owl:NamedIndividual rdf:about="http://purls.helmholtz-metadaten.de/asmo/Langevin">
+        <rdf:type rdf:resource="http://purls.helmholtz-metadaten.de/asmo/Thermostat"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Langevin</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
     <!-- http://purls.helmholtz-metadaten.de/asmo/MicrocanonicalEnsemble -->
 
     <owl:NamedIndividual rdf:about="http://purls.helmholtz-metadaten.de/asmo/MicrocanonicalEnsemble">
@@ -1609,6 +1985,51 @@ prov:wasInfluencedBy should not be used without also using one of its subpropert
     
 
 
+    <!-- http://purls.helmholtz-metadaten.de/asmo/NoseHoover -->
+
+    <owl:NamedIndividual rdf:about="http://purls.helmholtz-metadaten.de/asmo/NoseHoover">
+        <rdf:type rdf:resource="http://purls.helmholtz-metadaten.de/asmo/Thermostat"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Nose-Hoover</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purls.helmholtz-metadaten.de/asmo/ParrinelloRahman -->
+
+    <owl:NamedIndividual rdf:about="http://purls.helmholtz-metadaten.de/asmo/ParrinelloRahman">
+        <rdf:type rdf:resource="http://purls.helmholtz-metadaten.de/asmo/Barostat"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Parrinello-Rahman</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purls.helmholtz-metadaten.de/asmo/PeriodicityInXdirection -->
+
+    <owl:NamedIndividual rdf:about="http://purls.helmholtz-metadaten.de/asmo/PeriodicityInXdirection">
+        <rdf:type rdf:resource="http://purls.helmholtz-metadaten.de/asmo/PeriodicBoundaryCondition"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Periodicity in X-direction</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purls.helmholtz-metadaten.de/asmo/PeriodicityInYdirection -->
+
+    <owl:NamedIndividual rdf:about="http://purls.helmholtz-metadaten.de/asmo/PeriodicityInYdirection">
+        <rdf:type rdf:resource="http://purls.helmholtz-metadaten.de/asmo/PeriodicBoundaryCondition"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Periodicity in Y-direction</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purls.helmholtz-metadaten.de/asmo/PeriodicityInZdirection -->
+
+    <owl:NamedIndividual rdf:about="http://purls.helmholtz-metadaten.de/asmo/PeriodicityInZdirection">
+        <rdf:type rdf:resource="http://purls.helmholtz-metadaten.de/asmo/PeriodicBoundaryCondition"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Periodicity in Z-direction</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
     <!-- http://purls.helmholtz-metadaten.de/asmo/SubstituteAtom -->
 
     <owl:NamedIndividual rdf:about="http://purls.helmholtz-metadaten.de/asmo/SubstituteAtom">
@@ -1625,6 +2046,15 @@ prov:wasInfluencedBy should not be used without also using one of its subpropert
         <rdf:type rdf:resource="http://purls.helmholtz-metadaten.de/asmo/EquationOfStateFit"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EOS calculation using a third-order polynomial fit.</obo:IAO_0000115>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Third-order polynomial fit</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purls.helmholtz-metadaten.de/asmo/VelocityRescaling -->
+
+    <owl:NamedIndividual rdf:about="http://purls.helmholtz-metadaten.de/asmo/VelocityRescaling">
+        <rdf:type rdf:resource="http://purls.helmholtz-metadaten.de/asmo/Thermostat"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Velocity Rescaling</rdfs:label>
     </owl:NamedIndividual>
     
 

--- a/atomrdf/data/asmo.owl
+++ b/atomrdf/data/asmo.owl
@@ -1891,6 +1891,24 @@ prov:wasInfluencedBy should not be used without also using one of its subpropert
     
 
 
+    <!-- http://purls.helmholtz-metadaten.de/asmo/ExplicitKPointMesh -->
+
+    <owl:NamedIndividual rdf:about="http://purls.helmholtz-metadaten.de/asmo/ExplicitKPointMesh">
+        <rdf:type rdf:resource="http://purls.helmholtz-metadaten.de/asmo/KPointMesh"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Explicit KPoint Mesh</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purls.helmholtz-metadaten.de/asmo/GammaCenteredKPointMesh -->
+
+    <owl:NamedIndividual rdf:about="http://purls.helmholtz-metadaten.de/asmo/GammaCenteredKPointMesh">
+        <rdf:type rdf:resource="http://purls.helmholtz-metadaten.de/asmo/KPointMesh"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gamma-Centered KPoint Mesh</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
     <!-- http://purls.helmholtz-metadaten.de/asmo/GrandCanonicalEnsemble -->
 
     <owl:NamedIndividual rdf:about="http://purls.helmholtz-metadaten.de/asmo/GrandCanonicalEnsemble">
@@ -1944,6 +1962,15 @@ prov:wasInfluencedBy should not be used without also using one of its subpropert
         <obo:IAO_0000119 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ISBN-13: 978-0323902922</obo:IAO_0000119>
         <rdfs:label>Microcanonical Ensemble</rdfs:label>
         <skos:altLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NVE ensemble</skos:altLabel>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purls.helmholtz-metadaten.de/asmo/MonkhorstPackKPointMesh -->
+
+    <owl:NamedIndividual rdf:about="http://purls.helmholtz-metadaten.de/asmo/MonkhorstPackKPointMesh">
+        <rdf:type rdf:resource="http://purls.helmholtz-metadaten.de/asmo/KPointMesh"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Monkhorst Pack KPoint Mesh</rdfs:label>
     </owl:NamedIndividual>
     
 

--- a/atomrdf/data/asmo.owl
+++ b/atomrdf/data/asmo.owl
@@ -773,7 +773,6 @@ prov:wasInfluencedBy should not be used without also using one of its subpropert
 
     <owl:ObjectProperty rdf:about="https://w3id.org/mdo/calculation/hasXCFunctional">
         <rdfs:domain rdf:resource="http://purls.helmholtz-metadaten.de/asmo/DensityFunctionalTheory"/>
-        <rdfs:domain rdf:resource="https://w3id.org/mdo/calculation/DensityFunctionalTheoryMethod"/>
         <rdfs:range rdf:resource="https://w3id.org/mdo/calculation/ExchangeCorrelationEnergyFunctional"/>
         <rdfs:comment xml:lang="en">hasXCFunctional represents the relationship between a density functional theory method and the exchange-correlation energy functionals it takes.</rdfs:comment>
         <rdfs:label xml:lang="en">has XC functional</rdfs:label>
@@ -1027,7 +1026,6 @@ prov:wasInfluencedBy should not be used without also using one of its subpropert
     <!-- http://purls.helmholtz-metadaten.de/asmo/DensityFunctionalTheory -->
 
     <owl:Class rdf:about="http://purls.helmholtz-metadaten.de/asmo/DensityFunctionalTheory">
-        <owl:equivalentClass rdf:resource="https://w3id.org/mdo/calculation/DensityFunctionalTheoryMethod"/>
         <rdfs:subClassOf rdf:resource="http://purls.helmholtz-metadaten.de/asmo/ComputationalMethod"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Density functional theory is a computational method used to study the electronic structure and ground state of atoms, molecules, and, solids. This technique determines the properties of a many-electron system thorugh functionals of the spatially dependent electron density.</obo:IAO_0000115>
         <rdfs:label>Density Functional Theory</rdfs:label>
@@ -1707,29 +1705,6 @@ prov:wasInfluencedBy should not be used without also using one of its subpropert
         <prov:definition xml:lang="en">A software agent is running software.</prov:definition>
         <prov:dm rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-agent</prov:dm>
         <prov:n rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-types</prov:n>
-    </owl:Class>
-    
-
-
-    <!-- https://w3id.org/mdo/calculation/DensityFunctionalTheoryMethod -->
-
-    <owl:Class rdf:about="https://w3id.org/mdo/calculation/DensityFunctionalTheoryMethod">
-        <rdfs:subClassOf>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="https://w3id.org/mdo/calculation/hasXCFunctional"/>
-                        <owl:someValuesFrom rdf:resource="https://w3id.org/mdo/calculation/ExchangeCorrelationEnergyFunctional"/>
-                    </owl:Restriction>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="https://w3id.org/mdo/calculation/hasXCFunctional"/>
-                        <owl:allValuesFrom rdf:resource="https://w3id.org/mdo/calculation/ExchangeCorrelationEnergyFunctional"/>
-                    </owl:Restriction>
-                </owl:intersectionOf>
-            </owl:Class>
-        </rdfs:subClassOf>
-        <rdfs:comment xml:lang="en">A DFT method is a computational quantum mechanical modelling method used to investigate the electronic structure based on optimization of the energy over electronic densities.</rdfs:comment>
-        <rdfs:label xml:lang="en">Density Functional Theory Method</rdfs:label>
     </owl:Class>
     
 

--- a/atomrdf/data/cmso.owl
+++ b/atomrdf/data/cmso.owl
@@ -842,7 +842,7 @@ f(x) = 1/(√(2 π) σ) e^-((x - μ)^2/(2 σ^2))</obo:IAO_0000112>
 
     <owl:DatatypeProperty rdf:about="http://purls.helmholtz-metadaten.de/cmso/hasRepetition_x">
         <rdfs:domain rdf:resource="http://purls.helmholtz-metadaten.de/cmso/SimulationCell"/>
-        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#float"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A data property linking a simulation cell with its number of repetitions in the x direction.</obo:IAO_0000115>
         <rdfs:label>has repetition x</rdfs:label>
     </owl:DatatypeProperty>
@@ -853,7 +853,7 @@ f(x) = 1/(√(2 π) σ) e^-((x - μ)^2/(2 σ^2))</obo:IAO_0000112>
 
     <owl:DatatypeProperty rdf:about="http://purls.helmholtz-metadaten.de/cmso/hasRepetition_y">
         <rdfs:domain rdf:resource="http://purls.helmholtz-metadaten.de/cmso/SimulationCell"/>
-        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#float"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A data property linking a simulation cell with its number of repetitions in the y direction.</obo:IAO_0000115>
         <rdfs:label>has repetition y</rdfs:label>
     </owl:DatatypeProperty>
@@ -864,7 +864,7 @@ f(x) = 1/(√(2 π) σ) e^-((x - μ)^2/(2 σ^2))</obo:IAO_0000112>
 
     <owl:DatatypeProperty rdf:about="http://purls.helmholtz-metadaten.de/cmso/hasRepetition_z">
         <rdfs:domain rdf:resource="http://purls.helmholtz-metadaten.de/cmso/SimulationCell"/>
-        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#float"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A data property linking a simulation cell with its number of repetitions in the z direction.</obo:IAO_0000115>
         <rdfs:label>has repetition z</rdfs:label>
     </owl:DatatypeProperty>

--- a/atomrdf/namespace.py
+++ b/atomrdf/namespace.py
@@ -69,8 +69,9 @@ class Namespace(AttrSetter, RDFLibNamespace):
         # now iterate over all attributes
         for k1 in ["class", "object_property", "data_property"]:
             for k2, val in self.network.onto.attributes[k1].items():
-                if val.namespace == self.name:
-                    mapdict[val.name_without_prefix] = val
+                #print(val.namespace, self.name)
+                #if val.namespace == self.name:
+                mapdict[val.name_without_prefix] = val
 
         # add attributes
         self._add_attribute(mapdict)

--- a/atomrdf/namespace.py
+++ b/atomrdf/namespace.py
@@ -62,8 +62,8 @@ class Namespace(AttrSetter, RDFLibNamespace):
         """
         AttrSetter.__init__(self)
         self.network = OntologyNetwork(infile)
-        RDFLibNamespace.__init__(self.network.onto.tree.base_iri)
-        self.name = self.network.onto.tree.name
+        RDFLibNamespace.__init__(self.network.onto.base_iri)
+        self.name = self.network.onto.base_iri.split('/')[-1]
         mapdict = {}
 
         # now iterate over all attributes

--- a/atomrdf/namespace.py
+++ b/atomrdf/namespace.py
@@ -61,7 +61,7 @@ class Namespace(AttrSetter, RDFLibNamespace):
             The delimiter used in the input file. Defaults to "/".
         """
         AttrSetter.__init__(self)
-        self.network = OntologyNetwork(infile, delimiter=delimiter)
+        self.network = OntologyNetwork(infile)
         RDFLibNamespace.__init__(self.network.onto.tree.base_iri)
         self.name = self.network.onto.tree.name
         mapdict = {}

--- a/atomrdf/network/network.py
+++ b/atomrdf/network/network.py
@@ -127,8 +127,7 @@ class OntologyNetwork:
         """
         if namespace_name not in self.onto.namespaces.keys():
             self.onto.namespaces[namespace_name] = namespace_iri
-        else:
-            raise KeyError("namespace is already there!")
+   
 
     def add_term(
         self,

--- a/atomrdf/network/network.py
+++ b/atomrdf/network/network.py
@@ -212,6 +212,7 @@ class OntologyNetwork:
             raise ValueError(f"{sub} not found in self.attributes")
 
         # now add
+        self.g.add_edge(sub, pred)
         for subclass in self.onto.attributes['class'][sub].subclasses:
             self.g.add_edge(subclass, pred)
 
@@ -220,6 +221,7 @@ class OntologyNetwork:
             if obj not in self.onto.attributes["class"].keys():
                 raise ValueError(f"{obj} not found in self.attributes")
             #subclasses = self.onto._get_subclasses(obj)
+            self.g.add_edge(pred, obj)
             for subclass in self.onto.attributes['class'][obj].subclasses:
                 self.g.add_edge(pred, subclass)
 

--- a/atomrdf/network/network.py
+++ b/atomrdf/network/network.py
@@ -24,12 +24,12 @@ class OntologyNetwork:
     Network representation of Onto
     """
 
-    def __init__(self, infile=None, delimiter="/"):
+    def __init__(self, infile=None):
         if infile is None:
             infile = owlfile
 
         self.g = nx.DiGraph()
-        self.onto = OntoParser(infile, delimiter=delimiter)
+        self.onto = OntoParser(infile)
         self.onto.attributes["data_node"] = []
         self.data_prefix = "value"
         self.terms = AttrSetter()

--- a/atomrdf/network/ontology.py
+++ b/atomrdf/network/ontology.py
@@ -102,6 +102,9 @@ def read_ontology():
     combo.add_path(("cmso:Material", "cmso:hasDefect", "ldo:LineDefect"))
     combo.add_path(("cmso:Material", "cmso:hasDefect", "ldo:Dislocation"))
 
+    #CMSO -> PODO DISL paths
+    combo.add_path(("cmso:Material", "cmso:hasDefect", "pldo:GrainBoundary"))
+
 
     combo.add_path(("cmso:ComputationalSample", "prov:wasDerivedFrom", "cmso:ComputationalSample"))
     combo.add_path(("cmso:ComputationalSample", "rdf:type", "prov:Entity"))

--- a/atomrdf/network/ontology.py
+++ b/atomrdf/network/ontology.py
@@ -103,22 +103,12 @@ def read_ontology():
     combo.add_path(("cmso:Material", "cmso:hasDefect", "ldo:Dislocation"))
 
 
-    combo.add_path(
-        ("cmso:ComputationalSample", "prov:wasDerivedFrom", "cmso:ComputationalSample")
-    )
+    combo.add_path(("cmso:ComputationalSample", "prov:wasDerivedFrom", "cmso:ComputationalSample"))
     combo.add_path(("cmso:ComputationalSample", "rdf:type", "prov:Entity"))
     combo.add_path(("cmso:AtomicScaleSample", "prov:wasGeneratedBy", "prov:Activity"))
     combo.add_path(("asmo:EnergyCalculation", "rdf:type", "prov:Activity"))
-    combo.add_path(
-        ("asmo:EnergyCalculation", "prov:wasAssociatedWith", "prov:SoftwareAgent")
-    )
-    combo.add_path(
-        (
-            "cmso:ComputationalSample",
-            "prov:wasGeneratedBy",
-            "asmo:EnergyCalculation",
-        )
-    )
+    combo.add_path(("asmo:EnergyCalculation", "prov:wasAssociatedWith", "prov:SoftwareAgent"))
+    combo.add_path(("cmso:ComputationalSample","prov:wasGeneratedBy","asmo:EnergyCalculation",))
     
     combo.add_path(("cmso:CalculatedProperty", "asmo:hasValue", "float"))
     #combo.add_path(("cmso:CalculatedProperty", "asmo:hasUnit", "string"))
@@ -134,6 +124,13 @@ def read_ontology():
     combo.add_path(("prov:SoftwareAgent", "rdfs:label", "string"))
     combo.add_path(("asmo:InteratomicPotential", "cmso:hasReference", "string"))
     combo.add_path(("asmo:InteratomicPotential", "rdfs:label", "string"))
+
+    #now more paths
+    combo.add_path(("prov:Activity", "asmo:hasInputParameter", "asmo:InputParameter"))
+    combo.add_path(("cmso:CalculatedProperty", "asmo:wasCalculatedBy", "prov:Activity"))
+    combo.add_path(("cmso:ComputationalSample", "cmso:hasCalculatedProperty", "cmso:CalculatedProperty"))
+    combo.add_path(("cmso:ComputationalSample", "cmso:hasCalculatedProperty", "asmo:PhysicalQuantity"))
+    combo.add_path(("cmso:ComputationalSample", "cmso:hasCalculatedProperty", "asmo:OutputParameter"))
 
 
     # return

--- a/atomrdf/network/ontology.py
+++ b/atomrdf/network/ontology.py
@@ -110,7 +110,7 @@ def read_ontology():
     combo.add_path(("asmo:EnergyCalculation", "prov:wasAssociatedWith", "prov:SoftwareAgent"))
     combo.add_path(("cmso:ComputationalSample","prov:wasGeneratedBy","asmo:EnergyCalculation",))
     
-    combo.add_path(("cmso:CalculatedProperty", "asmo:hasValue", "float"))
+    combo.add_path(("cmso:CalculatedProperty", "cmso:hasValue", "float"))
     #combo.add_path(("cmso:CalculatedProperty", "asmo:hasUnit", "string"))
     combo.add_path(("cmso:CalculatedProperty", "rdfs:label", "string"))
     #how to handle units?
@@ -118,7 +118,7 @@ def read_ontology():
     #input parameters for ASMO
     combo.add_path(("asmo:InputParameter", "rdfs:label", "string"))
     #combo.add_path(("cmso:CalculatedProperty", "asmo:hasUnit", "string"))
-    combo.add_path(("asmo:InputParameter", "asmo:hasValue", "float"))
+    combo.add_path(("asmo:InputParameter", "cmso:hasValue", "float"))
 
     #software agent
     combo.add_path(("prov:SoftwareAgent", "rdfs:label", "string"))

--- a/atomrdf/network/parser.py
+++ b/atomrdf/network/parser.py
@@ -31,7 +31,8 @@ class OntoParser:
         self.parse_equivalents()
         self.parse_named_individuals()
         self.extract_object_properties()
-        self.extract_data_properties()        
+        self.extract_data_properties()
+        self.recheck_namespaces()        
 
     def __add__(self, ontoparser):
         """
@@ -60,7 +61,7 @@ class OntoParser:
     def __radd__(self, ontoparser):
         return self.__add__(ontoparser)
 
-    def _recheck_namespaces(self):
+    def recheck_namespaces(self):
         for mainkey in self.attributes.keys():
             for key, val in self.attributes[mainkey].items():
                 namespace = self.attributes[mainkey][key].namespace

--- a/atomrdf/network/parser.py
+++ b/atomrdf/network/parser.py
@@ -99,11 +99,7 @@ class OntoParser:
             term.domain = self.get_domain(cls)
             rrange = self.get_range(cls)
             rrange = [x.split(":")[-1] for x in rrange]
-            for i in range(len(rrange)):
-                if rrange[i] == "string":
-                    rrange[i] = "str"
-                elif rrange[i] == "integer":
-                    rrange[i] = "int"
+            rrange = patch_terms(term.uri, rrange)
 
             term.range = rrange
             term.node_type = "data_property"

--- a/atomrdf/network/parser.py
+++ b/atomrdf/network/parser.py
@@ -99,6 +99,12 @@ class OntoParser:
             term.domain = self.get_domain(cls)
             rrange = self.get_range(cls)
             rrange = [x.split(":")[-1] for x in rrange]
+            for i in range(len(rrange)):
+                if rrange[i] == "string":
+                    rrange[i] = "str"
+                elif rrange[i] == "integer":
+                    rrange[i] = "int"
+
             term.range = rrange
             term.node_type = "data_property"
             self.attributes["data_property"][term.name] = term

--- a/atomrdf/network/parser.py
+++ b/atomrdf/network/parser.py
@@ -1,6 +1,3 @@
-from owlready2 import get_ontology
-import owlready2
-
 import os
 import copy
 import numpy as np
@@ -11,26 +8,30 @@ from atomrdf.network.patch import patch_terms
 
 
 class OntoParser:
-    def __init__(self, infile, delimiter="/"):
-        if os.path.exists(infile):
-            self.tree = get_ontology(f"file://{infile}").load()
-        elif infile[:4] == "http":
-            self.tree = get_ontology(infile)
-        else:
+    def __init__(self, infile, format='xml'):
+        if not os.path.exists(infile):
             raise FileNotFoundError(f"file {infile} not found!")
+        
+        self.graph = Graph()
+        self.graph.parse(infile, format=format)
+        self.classes = []
         self.attributes = {}
         self.attributes["class"] = {}
         self.attributes["object_property"] = {}
         self.attributes["data_property"] = {}
         self.delimiter = delimiter
-        self.classes = None
-        self.namespaces = {self.tree.name: self.tree.base_iri}
+        self.mappings = {}
+        self.namespaces = {}
         self.extra_namespaces = {}
-        self._parse_class()
-        # print(self.attributes)
-        self._parse_object_property()
-        self._parse_data_property()
-        self._recheck_namespaces()
+
+        self.extract_classes()
+        self.extract_relations(relation_type="union")
+        self.add_classes_to_attributes()
+        self.parse_subclasses()
+        self.parse_equivalents()
+        self.parse_named_individuals()
+        self.extract_object_properties()
+        self.extract_data_properties()        
 
     def __add__(self, ontoparser):
         """
@@ -59,20 +60,6 @@ class OntoParser:
     def __radd__(self, ontoparser):
         return self.__add__(ontoparser)
 
-    def _strip_datatype(self, uri, delimiter="#"):
-        uri_split = uri.split(delimiter)
-        return uri_split[-1]
-
-    def _dict_to_lst(self, d):
-        return [val for key, val in d.items()]
-
-    def _get_subclasses(self, name):
-        arg = self._in_which_bin_is_class(name)
-        if arg is not None:
-            return self.classes[arg]
-        else:
-            return [name]
-
     def _recheck_namespaces(self):
         for mainkey in self.attributes.keys():
             for key, val in self.attributes[mainkey].items():
@@ -82,201 +69,153 @@ class OntoParser:
                         key
                     ].namespace_with_prefix
 
-    def _add_info(self, term, c):
-        try:
-            term.description = c.IAO_0000115
-        except:
-            term.description = ""
-        try:
-            term.label = c.label
-        except:
-            term.label = ""
-        return term
+    def extract_classes(self):
+        self.classes = list(self.graph.subjects(RDF.type, OWL.Class))
 
-    def _unravel(self, d):
-        try:
-            return [x for x in d.Classes]
-        except:
-            return [d]
-
-    def _clean_domain_list(self, dm):
-        try:
-            dm_list = [d for d in dm[0].Classes]
-        except:
-            dm_list = []
-            for d in dm:
-                dm_list.extend(self._unravel(d))
-        return dm_list
-
-    def _parse_data_property(self):
-        for c in self.tree.data_properties():
-            iri = c.iri
-            dm = c.domain
-            dm_list = self._clean_domain_list(dm)
-            dm = [strip_name(d.iri, self.delimiter) for d in dm_list]
-
-            # now get subclasses
-            dm = [self._get_subclasses(d) for d in dm]
-            dm = list(itertools.chain(*dm))
-
-            rn = c.range
-            try:
-                rn = [r.__name__ for r in rn[0].Classes if r is not None]
-            except:
-                rn = [r.__name__ for r in rn if r is not None]
-
-            # Subproperties
-            # Commented out for now
-            # subprops = self.tree.search(subproperty_of=getattr(self.tree, c.name))
-            # for subprop in subprops:
-            #    if subprop.iri != iri:
-            #        #print(subprop.iri)
-            #        pass
-
-            # PATCH
-            # Here: we patch specific items specifically for pyscal rdf
-            rn = patch_terms(iri, rn)
-
-            # print(iri, rn)
-            # print(iri, dm)
-            term = OntoTerm(iri, delimiter=self.delimiter)
-            dm = [x.replace("07:owl#Thing", "owl:Thing") for x in dm]
-            term.domain = dm
-            term.range = rn
-            term.node_type = "data_property"
-            term = self._add_info(term, c)
-
-            self.attributes["data_property"][term.name] = term
-            # assign this data
-            for d in dm:
-                if d != "owl:Thing":
-                    self.attributes["class"][d].is_domain_of.append(term.name)
-
-            # subproperties should be treated the same
-
-    def _parse_object_property(self):
-        for c in self.tree.object_properties():
-            iri = c.iri
-            dm = c.domain
-            try:
-                dm = [strip_name(d.iri, self.delimiter) for d in dm[0].Classes]
-            except:
-                dmnew = []
-                for d in dm:
-                    if isinstance(d, owlready2.class_construct.Or):
-                        for x in d.Classes:
-                            dmnew.append(strip_name(x.iri, self.delimiter))
-                    else:
-                        dmnew.append(strip_name(d.iri, self.delimiter))
-                dm = dmnew
-
-            # now get subclasses
-            dm = [self._get_subclasses(d) for d in dm]
-            dm = list(itertools.chain(*dm))
-
-            rn = c.range
-            try:
-                rn = [strip_name(r.iri, self.delimiter) for r in rn[0].Classes]
-            except:
-                rn = [strip_name(r.iri, self.delimiter) for r in rn]
-
-            # now get subclasses
-            rn = [self._get_subclasses(d) for d in rn]
-            rn = list(itertools.chain(*rn))
-
-            term = OntoTerm(iri, delimiter=self.delimiter)
-            term.domain = dm
-            term.range = rn
-            term = self._add_info(term, c)
+    def extract_object_properties(self):
+        object_properties = list(self.graph.subjects(RDF.type, OWL.ObjectProperty))
+        for cls in object_properties:
+            term = self.create_term(cls)
+            term.domain = self.get_domain(cls)
+            term.range = self.get_range(cls)
             term.node_type = "object_property"
-            self.attributes["object_property"][term.name] = term
-            for d in dm:
-                if d != "07:owl#Thing":
-                    if d in self.attributes["class"]:
-                        self.attributes["class"][d].is_domain_of.append(term.name)
-            for r in rn:
-                if r != "07:owl#Thing":
-                    if r in self.attributes["class"]:
-                        self.attributes["class"][r].is_range_of.append(term.name)
+            self.attributes["object_property"][term.name] = term            
 
-    def _parse_class_basic(self):
-        classes = []
-        for c in self.tree.classes():
-            iri = c.iri
-            print(iri)
-            # print(iri)
-            # print(iri)
-            # CHILDREN
-            children = self.tree.get_children_of(c)
-            named_instances = self.tree.get_instances_of(c)
-            equiv_classes = c.equivalent_to
-            subclasses = [*children, *named_instances, *equiv_classes]
-            subclasses.append(c)
-            for sb in subclasses:
-                term = OntoTerm(sb.iri, delimiter=self.delimiter)
-                term = self._add_info(term, sb)
-                term.node_type = "class"
-                self.attributes["class"][term.name] = term
-            subclasses = [strip_name(sb.iri, self.delimiter) for sb in subclasses]
-            classes.append(subclasses)
+    def extract_data_properties(self):
+        data_properties = list(self.graph.subjects(RDF.type, OWL.DatatypeProperty))
+        for cls in data_properties:
+            term = self.create_term(cls)
+            term.domain = self.get_domain(cls)
+            rrange = self.get_range(cls)
+            rrange = [x.split(":")[-1] for x in rrange]
+            term.range = rrange
+            term.node_type = "data_property"
+            self.attributes["data_property"][term.name] = term
 
-            # try:
-            #    subclasses = self.tree.search(subclass_of=getattr(self.tree, c.name))
-            #    for sb in subclasses:
-            #        term = OntoTerm(sb.iri, delimiter=self.delimiter)
-            #        term.node_type ='class'
-            #        self.attributes['class'][term.name] = term
-            #    subclasses = [strip_name(sb.iri, self.delimiter) for sb in subclasses]
-            #    classes.append(subclasses)
-            # except:
-            #    term = OntoTerm(c.iri, delimiter=self.delimiter)
-            #    term.node_type ='class'
-            #    self.attributes['class'][term.name] = term
-            #    classes.append([strip_name(c.iri, self.delimiter)])
-        return classes
-
-    def _aggregate_keys(self, dd):
-        lst = copy.deepcopy(dd)
-        # choose the first list
-        large_list = []
-        start = lst[0]
-        # delete it from the main list
-        nruns = len(lst)
-        del lst[0]
-        # now loop, if there is intersection add to this list
-        while True:
-            found = False
-            index_to_delete = []
-            for count, ls in enumerate(lst):
-                common = len(list(set(start) & set(ls)))
-                # print(common)
-                if common > 0:
-                    # common elements found! merge them
-                    for l in ls:
-                        start.append(l)
-                    found = True
-                    index_to_delete.append(count)
-            if found:
-                for ii in index_to_delete[::-1]:
-                    del lst[ii]
-            else:
-                large_list.append(np.unique(start))
-                if len(lst) == 0:
-                    break
-                else:
-                    start = lst[0]
-                    del lst[0]
-        return large_list
-
-    def _parse_class(self):
-        sub_classes = self._parse_class_basic()
-        # now we have to go through and clean up sub classes
-        sub_classes = self._aggregate_keys(sub_classes)
-        self.classes = sub_classes
-
-    def _in_which_bin_is_class(self, name):
-        for count, lst in enumerate(self.classes):
-            if name in lst:
-                return count
+            #now create data nodes
+            data_term = OntoTerm()
+            data_term.name = term.name + "value"
+            data_term.node_type = "data_node"
+            self.attributes["data_property"][term.name].associated_data_node = data_term.name
+            self.attributes["data_nodes"][data_term.name] = data_term   
+    
+    def extract_values(self, subject, predicate):
+        vallist = list([x[2] for x in self.graph.triples((subject, predicate, None))])
+        if len(vallist) > 0:
+            return vallist[0]
         else:
             return None
+            
+    def extract_relations(self, relation_type):
+        if relation_type == "union":
+            owl_term = OWL.unionOf
+        elif relation_type == "intersection":
+            owl_term = OWL.intersectionOf
+            
+        to_delete = []
+        for term in self.classes:
+            if isinstance(term, BNode):
+                union_term = self.extract_values(term, owl_term)
+                if union_term is not None:
+                    unravel_list = []
+                    self.unravel_relation(union_term, unravel_list)
+                    self.mappings[term.toPython()] = {"type": relation_type, "items": [strip_name(item.toPython()) for item in unravel_list]}
+                    to_delete.append(term)
+        for term in to_delete:
+            self.classes.remove(term)
+
+    def add_classes_to_attributes(self):
+        for cls in self.classes:
+            term = self.create_term(cls)
+            term.node_type = "class"
+            self.attributes["class"][term.name] = term
+
+    def get_description(self, cls):
+        comment = self.graph.value(cls, URIRef('http://purl.obolibrary.org/obo/IAO_0000115'))
+        if comment is None:
+            comment = self.graph.value(cls, URIRef('http://www.w3.org/2000/01/rdf-schema#comment'))
+        if comment is None:
+            comment = ""
+        return comment
+
+    def lookup_node(self, term):
+        if isinstance(term, BNode):
+            #lookup needed
+            term_name = term.toPython()
+            if term_name in self.mappings:
+                terms = self.mappings[term_name]['items']
+            else:
+                terms = [strip_name(term.toPython())]
+        else:
+            terms = [strip_name(term.toPython())]
+        #so here we map the domain and range wrt to other heirarchies
+        additional_terms = []
+        #first get subclasses which will share the domain and range
+        for term in terms:
+            #check if such a thing exists in the class 
+            if term in self.attributes['class']:
+                #get the subclasses
+                additional_terms += self.attributes['class'][term].subclasses
+                #get the equivalent classes
+                additional_terms += self.attributes['class'][term].equivalent_classes
+                #get the named individuals
+                additional_terms += self.attributes['class'][term].named_individuals
+        #add additiona terms to terms
+        terms += additional_terms
+        return terms
+        
+    def get_domain(self, cls):
+        domain = []
+        for triple in self.graph.triples((cls, URIRef('http://www.w3.org/2000/01/rdf-schema#domain'), None)):
+            domain_term = self.lookup_node(triple[2])
+            for term in domain_term:
+                domain.append(term)
+        return domain
+
+    def get_range(self, cls):
+        rrange = []
+        for triple in self.graph.triples((cls, URIRef('http://www.w3.org/2000/01/rdf-schema#range'), None)):
+            range_term = self.lookup_node(triple[2])
+            for term in range_term:
+                rrange.append(term)
+        return rrange
+        
+    def create_term(self, cls):
+        iri = cls.toPython()
+        term = OntoTerm(iri, delimiter=self.delimiter)
+        term.description = self.get_description(cls)
+        term._object = cls
+        return term
+                    
+    def unravel_relation(self, term, unravel_list):
+        if term == RDF.nil:
+            return 
+        first_term = self.graph.value(term, RDF.first)
+        if first_term not in unravel_list:
+            unravel_list.append(first_term)
+        second_term =  self.graph.value(term, RDF.rest)
+        self.unravel_relation(second_term, unravel_list)
+
+    def parse_subclasses(self):
+        for key, cls in self.attributes['class'].items():
+            for triple in self.graph.triples((cls._object, RDFS.subClassOf, None)):
+                superclass = triple[2]
+                self.attributes['class'][strip_name(superclass)].subclasses.append(cls.name)
+    
+    def parse_equivalents(self):
+        for key, cls in self.attributes['class'].items():
+            for triple in self.graph.triples((cls._object, OWL.equivalentClass, None)):
+                equivalent = triple[2]
+                self.attributes['class'][strip_name(equivalent)].equivalent_classes.append(cls.name)
+                cls.equivalent_classes.append(strip_name(equivalent))
+    
+    def parse_named_individuals(self):
+        named_individuals = list(self.graph.subjects(RDF.type, OWL.NamedIndividual))
+        for cls in named_individuals:
+            #find parent
+            term = self.create_term(cls)
+            self.attributes["class"][term.name] = term
+            parents = list(self.graph.objects(cls, RDF.type))
+            for parent in parents:
+                if parent != OWL.NamedIndividual:
+                    self.attributes["class"][strip_name(parent.toPython())].named_individuals.append(term.name)

--- a/atomrdf/network/parser.py
+++ b/atomrdf/network/parser.py
@@ -93,14 +93,27 @@ class OntoParser:
             term.label = ""
         return term
 
+    def _unravel(self, d):
+        try:
+            return [x for x in d.Classes]
+        except:
+            return [d]
+
+    def _clean_domain_list(self, dm):
+        try:
+            dm_list = [d for d in dm[0].Classes]
+        except:
+            dm_list = []
+            for d in dm:
+                dm_list.extend(self._unravel(d))
+        return dm_list
+
     def _parse_data_property(self):
         for c in self.tree.data_properties():
             iri = c.iri
             dm = c.domain
-            try:
-                dm = [strip_name(d.iri, self.delimiter) for d in dm[0].Classes]
-            except:
-                dm = [strip_name(d.iri, self.delimiter) for d in dm]
+            dm_list = self._clean_domain_list(dm)
+            dm = [strip_name(d.iri, self.delimiter) for d in dm_list]
 
             # now get subclasses
             dm = [self._get_subclasses(d) for d in dm]
@@ -190,6 +203,7 @@ class OntoParser:
         classes = []
         for c in self.tree.classes():
             iri = c.iri
+            print(iri)
             # print(iri)
             # print(iri)
             # CHILDREN

--- a/atomrdf/network/patch.py
+++ b/atomrdf/network/patch.py
@@ -17,39 +17,24 @@ def patch_terms(iri, rn):
     # Reason: Range is not specified in the owl file.
     # This prevents owlready2 from reading in this property correctly.
     if iri == "http://purls.helmholtz-metadaten.de/cmso/hasSymbol":
-        rn = ["str"]
+        rn += ["str"]
     # Term: hasValue
     # Ontology: CMSO
     # Reason: Range is Literal(); however here we use this for number values, hence we can fix this.
     # See fn: `add_calculated_property`
     elif iri == "http://purls.helmholtz-metadaten.de/cmso/hasValue":
-        rn = ["float", "double", "int", "str"]
-
-    elif iri == "http://purls.helmholtz-metadaten.de/cmso/hasRepetition_x":
-        rn = ["float", "double", "int"]
-
-    elif iri == "http://purls.helmholtz-metadaten.de/cmso/hasRepetition_y":
-        rn = ["float", "double", "int"]
-
-    elif iri == "http://purls.helmholtz-metadaten.de/cmso/hasRepetition_z":
-        rn = ["float", "double", "int"]
-
-    elif iri == "http://purls.helmholtz-metadaten.de/asmo/hasValue":
-        rn = ["float", "double", "int", "str"]
-
-    #elif iri == "http://purls.helmholtz-metadaten.de/asmo/hasUnit":
-    #    rn = ["str"]
-
-    #elif iri == "http://purls.helmholtz-metadaten.de/cmso/hasUnit":
-    #    rn = ["str"]
+        rn += ["float", "double", "int", "str"]
 
     elif iri == "http://www.w3.org/2000/01/rdf-schema#label":
-        rn = ["str"]
+        rn += ["str"]
 
     elif iri == "http://purls.helmholtz-metadaten.de/cmso/hasReference":
-        rn = ["str"]
+        rn += ["str"]
 
-    elif iri == 'http://purls.helmholtz-metadaten.de/cmso/hasSpaceGroupSymbol':
-        rn = ["str"]
+    for i in range(len(rn)):
+        if rn[i] == "string":
+            rn[i] = "str"
+        elif rn[i] == "integer":
+            rn[i] = "int"    
 
     return rn

--- a/atomrdf/network/term.py
+++ b/atomrdf/network/term.py
@@ -23,6 +23,19 @@ def _get_namespace_and_name(uri):
             namespace = ""
     return namespace, name
 
+def _get_namespace_with_prefix(uri):
+    uri_split = uri.split('#')
+    if len(uri_split) > 1:
+        #possible that delimiter is #
+        namespace = uri_split[0]
+    else:
+        uri_split = uri.split('/')
+        if len(uri_split) > 1:
+            namespace = "/".join(uri_split[-1])
+        else:
+            namespace = ""
+    return namespace
+
 def strip_name(uri, get_what="name", namespace=None):
     namespace, name = _get_namespace_and_name(uri)
     if get_what == "namespace":
@@ -198,23 +211,18 @@ class OntoTerm:
         else:
             return strip_name(self.uri, get_what="namespace")
 
-    #@property
-    #def namespace_with_prefix(self):
-    #    """
-    #    Get the namespace of the term with the prefix.
-    #
-    #    Returns
-    #    -------
-    #    str
-    #        The namespace of the term with the prefix.
-    #    """
-    #    uri_split = self.uri.split(self.delimiter)
-    #    if len(uri_split) > 1:
-    #        namespace = self.delimiter.join(uri_split[:-1]) + self.delimiter
-    #        return namespace
-    #    else:
-    #        return self.uri
-
+    @property
+    def namespace_with_prefix(self):
+        """
+        Get the namespace of the term with the prefix.
+    
+        Returns
+        -------
+        str
+            The namespace of the term with the prefix.
+        """
+        return _get_namespace_with_prefix(self.uri)
+        
     @property
     def namespace_object(self):
         """

--- a/atomrdf/network/term.py
+++ b/atomrdf/network/term.py
@@ -31,13 +31,18 @@ def _get_namespace_with_prefix(uri):
     else:
         uri_split = uri.split('/')
         if len(uri_split) > 1:
-            namespace = "/".join(uri_split[-1])
+            namespace = "/".join(uri_split[:-1])
         else:
             namespace = ""
+        if namespace[-1] != "#":
+            namespace += "/"
     return namespace
 
 def strip_name(uri, get_what="name", namespace=None):
-    namespace, name = _get_namespace_and_name(uri)
+    if namespace is None:
+        namespace, name = _get_namespace_and_name(uri)
+    else:
+        _, name = _get_namespace_and_name(uri)
     if get_what == "namespace":
         return namespace
 
@@ -173,7 +178,7 @@ class OntoTerm:
         if self._name is not None:
             return self._name
         return strip_name(
-            self.uri, get_what="name",
+            self.uri, get_what="name",namespace=self.namespace,
         )
     
     @name.setter
@@ -222,7 +227,7 @@ class OntoTerm:
             The namespace of the term with the prefix.
         """
         return _get_namespace_with_prefix(self.uri)
-        
+
     @property
     def namespace_object(self):
         """

--- a/atomrdf/network/term.py
+++ b/atomrdf/network/term.py
@@ -6,7 +6,6 @@ from rdflib import Namespace, URIRef
 import numbers
 import copy
 
-
 def _get_namespace_and_name(uri):
     uri_split = uri.split('#')
     if len(uri_split) > 1:
@@ -16,8 +15,12 @@ def _get_namespace_and_name(uri):
         namespace = namespace_split[-1]
     else:
         uri_split = uri.split('/')
-        name = uri_split[-1]
-        namespace = uri_split[-2]
+        if len(uri_split) > 1:
+            name = uri_split[-1]
+            namespace = uri_split[-2]
+        else:
+            name = uri_split[-1]
+            namespace = ""
     return namespace, name
 
 def strip_name(uri, get_what="name", namespace=None):
@@ -32,7 +35,7 @@ def strip_name(uri, get_what="name", namespace=None):
 class OntoTerm:
     def __init__(
         self,
-        uri,
+        uri = None,
         namespace=None,
         node_type=None,
         dm=[],
@@ -54,7 +57,10 @@ class OntoTerm:
         self.data_type = data_type
         # identifier
         self.node_id = node_id
+        self.associated_data_node = None
         self.subclasses = []
+        self.named_individuals = []
+        self.equivalent_classes = []
         self.subproperties = []
         self.delimiter = delimiter
         self.description = description
@@ -151,9 +157,15 @@ class OntoTerm:
         str
             The name of the term.
         """
+        if self._name is not None:
+            return self._name
         return strip_name(
             self.uri, get_what="name",
         )
+    
+    @name.setter
+    def name(self, val):
+        self._name = val
 
     @property
     def name_without_prefix(self):

--- a/atomrdf/structure.py
+++ b/atomrdf/structure.py
@@ -2359,7 +2359,8 @@ class System(pc.System):
         self.graph.add((burgers_vector, CMSO.hasComponent_z, Literal(disl_dict['BurgersVector'][2], datatype=XSD.float)))
         self.graph.add((line_defect, LDO.hasBurgersVector, burgers_vector))
 
-        self.graph.add((line_defect, LDO.hasCharacterAngle, Literal(angle_deg, datatype=XSD.float)))
+        if disl_name == "MixedDislocation":
+            self.graph.add((line_defect, LDO.hasCharacterAngle, Literal(angle_deg, datatype=XSD.float)))
 
         slip_direction = self.graph.create_node(f"{self._name}_DislocationSlipDirection", LDO.SlipDirection)
         self.graph.add((slip_direction, CMSO.hasComponent_x, Literal(disl_dict['SlipDirection'][0], datatype=XSD.float)))

--- a/atomrdf/workflow/workflow.py
+++ b/atomrdf/workflow/workflow.py
@@ -388,7 +388,7 @@ class Workflow:
                 label=out["label"],
             )
         
-        self.kg.add((prop, ASMO.hasValue, Literal(out["value"])))
+        self.kg.add((prop, CMSO.hasValue, Literal(out["value"])))
         if "unit" in out.keys():
             unit = out["unit"]
             self.kg.add(

--- a/atomrdf/workflow/workflow.py
+++ b/atomrdf/workflow/workflow.py
@@ -319,67 +319,67 @@ class Workflow:
 
         if base == 'TotalEnergy':
             prop = self.kg.create_node(
-                f'{main_id}_{out["label"]}', UNSAFEASMO.TotalEnergy,
+                f'{main_id}_{out["label"]}', ASMO.TotalEnergy,
                 label=out["label"],
             )
         elif base == 'PotentialEnergy':
             prop = self.kg.create_node(
-                f'{main_id}_{out["label"]}', UNSAFEASMO.PotentialEnergy,
+                f'{main_id}_{out["label"]}', ASMO.PotentialEnergy,
                 label=out["label"],
             )
         elif base == 'KineticEnergy':
             prop = self.kg.create_node(
-                f'{main_id}_{out["label"]}', UNSAFEASMO.KineticEnergy,
+                f'{main_id}_{out["label"]}', ASMO.KineticEnergy,
                 label=out["label"],
             )
         elif base == 'Volume':
             prop = self.kg.create_node(
-                f'{main_id}_{out["label"]}', UNSAFEASMO.Volume,
+                f'{main_id}_{out["label"]}', ASMO.Volume,
                 label=out["label"],
             )
         elif base == 'Pressure':
             prop = self.kg.create_node(
-                f'{main_id}_{out["label"]}', UNSAFEASMO.Pressure,
+                f'{main_id}_{out["label"]}', ASMO.Pressure,
                 label=out["label"],
             )
         elif base == 'Temperature':
             prop = self.kg.create_node(
-                f'{main_id}_{out["label"]}', UNSAFEASMO.Temperature,
+                f'{main_id}_{out["label"]}', ASMO.Temperature,
                 label=out["label"],
             )
         elif base == 'BulkModulus':
             prop = self.kg.create_node(
-                f'{main_id}_{out["label"]}', UNSAFEASMO.BulkModulus,
+                f'{main_id}_{out["label"]}', ASMO.BulkModulus,
                 label=out["label"],
             )
         elif base == 'FreeEnergy':
             prop = self.kg.create_node(
-                f'{main_id}_{out["label"]}', UNSAFEASMO.FreeEnergy,
+                f'{main_id}_{out["label"]}', ASMO.FreeEnergy,
                 label=out["label"],
             )
         elif base == 'EnergyCutoff':
             prop = self.kg.create_node(
-                f'{main_id}_{out["label"]}', UNSAFEASMO.EnergyCutoff,
+                f'{main_id}_{out["label"]}', ASMO.EnergyCutoff,
                 label=out["label"],
             )
         elif base == 'ExplicitKPointMesh':
             prop = self.kg.create_node(
-                f'{main_id}_{out["label"]}', UNSAFEASMO.ExplicitKPointMesh,
+                f'{main_id}_{out["label"]}', ASMO.ExplicitKPointMesh,
                 label=out["label"],
             )
         elif base == 'GammaCenteredKPointMesh':
             prop = self.kg.create_node(
-                f'{main_id}_{out["label"]}', UNSAFEASMO.GammaCenteredKPointMesh,
+                f'{main_id}_{out["label"]}', ASMO.GammaCenteredKPointMesh,
                 label=out["label"],
             )
         elif base == 'MonkhorstPackKPointMesh':
             prop = self.kg.create_node(
-                f'{main_id}_{out["label"]}', UNSAFEASMO.MonkhorstPackKPointMesh,
+                f'{main_id}_{out["label"]}', ASMO.MonkhorstPackKPointMesh,
                 label=out["label"],
             )
         elif base == 'KPointMesh':
             prop = self.kg.create_node(
-                f'{main_id}_{out["label"]}', UNSAFEASMO.KPointMesh,
+                f'{main_id}_{out["label"]}', ASMO.KPointMesh,
                 label=out["label"],
             )
         else:
@@ -388,13 +388,13 @@ class Workflow:
                 label=out["label"],
             )
         
-        self.kg.add((prop, UNSAFEASMO.hasValue, Literal(out["value"])))
+        self.kg.add((prop, ASMO.hasValue, Literal(out["value"])))
         if "unit" in out.keys():
             unit = out["unit"]
             self.kg.add(
                 (
                     prop,
-                    UNSAFEASMO.hasUnit,
+                    ASMO.hasUnit,
                     URIRef(f"http://qudt.org/vocab/unit/{unit}"),
                 )
             )
@@ -406,7 +406,7 @@ class Workflow:
         if "inputs" in job_dict.keys():
             for inp in job_dict["inputs"]:
                 prop = self._select_base_property(inp, main_id, ASMO.InputParameter)
-                self.kg.add((activity, UNSAFEASMO.hasInputParameter, prop))
+                self.kg.add((activity, ASMO.hasInputParameter, prop))
 
     def _add_outputs(self, job_dict, activity):
         main_id = job_dict['id']
@@ -415,10 +415,10 @@ class Workflow:
                 #here we add the classes by property
                 #call func here
                 prop = self._select_base_property(out, main_id, CMSO.CalculatedProperty)
-                self.kg.add((prop, UNSAFEASMO.wasCalculatedBy, activity))
+                self.kg.add((prop, ASMO.wasCalculatedBy, activity))
                 
                 if out["associate_to_sample"]:
-                    self.kg.add((job_dict['sample']['final'], UNSAFECMSO.hasCalculatedProperty, prop))
+                    self.kg.add((job_dict['sample']['final'], CMSO.hasCalculatedProperty, prop))
 
     def _add_software(self, job_dict, method):
         # finally add software

--- a/environment-docs.yml
+++ b/environment-docs.yml
@@ -12,7 +12,6 @@ dependencies:
   - ase 
   - networkx
   - pandas
-  - owlready2
   - jupyter-book
   - plotly
   - ipywidgets

--- a/environment-workflows.yml
+++ b/environment-workflows.yml
@@ -13,7 +13,6 @@ dependencies:
   - ase 
   - networkx
   - pandas
-  - owlready2
   - plotly
   - ipywidgets
   - atomman

--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,6 @@ dependencies:
   - ase =3.23.0
   - networkx
   - pandas
-  - owlready2
   - plotly
   - ipywidgets
   #- atomman

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     url = 'https://pyscal.org',
     install_requires=['numpy', 'ase', 'rdflib', 
     'pyyaml', 'graphviz', 'networkx', 
-    'pyscal3', 'spglib', 'pandas', 'owlready2',
+    'pyscal3', 'spglib', 'pandas',
     'atomman', 'mp-api', 'aimsgb', 'pymatgen', 'mendeleev'],
     classifiers=[
         'Programming Language :: Python :: 3'

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as readme_file:
 
 setup(
     name='atomrdf',
-    version='0.9.20',
+    version='0.10.0',
     author='Abril Azocar Guzman, Sarath Menon',
     author_email='sarath.menon@pyscal.org',
     description='Ontology based structural manipulation and quering',

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -99,14 +99,14 @@ def test_gb():
                         gb_plane=[3, -1, 0],
                         element='Fe',
                         graph=kg)
-	res = kg.query_sample(kg.ontology.terms.pldo.SymmetricalTiltGrainBoundary)
+	res = kg.query_sample(kg.ontology.terms.pldo.GrainBoundary)
 	assert len(res.AtomicScaleSample.values) == 1
 	
 	new = struct_gb_1.repeat((2,2,2))
-	res = kg.query_sample(kg.ontology.terms.pldo.SymmetricalTiltGrainBoundary)
+	res = kg.query_sample(kg.ontology.terms.pldo.GrainBoundary)
 	assert len(res.AtomicScaleSample.values) == 2
 
 	ss = kg.get_sample(new.sample)
-	res = ss.query_sample(ss.ontology.terms.pldo.SymmetricalTiltGrainBoundary)
+	res = ss.query_sample(ss.ontology.terms.pldo.GrainBoundary)
 	assert len(res.AtomicScaleSample.values) == 1
 


### PR DESCRIPTION
This pull request includes several changes to the `atomrdf` project, focusing on version updates, ontology data type modifications, and improvements to the ontology network parsing and handling. The most important changes include updating the version, modifying data types in the ontology, and refactoring the ontology network parsing.

Version updates:

* Updated the version in `.bumpversion.cfg` and `CITATION.cff` from `0.9.20` to `0.10.0`.

Ontology data type modifications:

* Changed the `rdfs:range` of `hasRepetition_x`, `hasRepetition_y`, and `hasRepetition_z` from `float` to `integer` in `atomrdf/data/cmso.owl`. 

Refactoring ontology network parsing:

* Removed the `delimiter` parameter from the `OntologyNetwork` and `OntoParser` classes, and refactored related methods in `atomrdf/namespace.py` and `atomrdf/network/network.py`. 
* Added methods to handle data nodes and improved edge handling in the ontology network in `atomrdf/network/network.py`. 
* Replaced `owlready2` with `rdflib` for ontology parsing in `atomrdf/network/parser.py`, and refactored the parsing methods accordingly.